### PR TITLE
Add foreground option

### DIFF
--- a/thold_daemon.php
+++ b/thold_daemon.php
@@ -33,7 +33,7 @@ $no_http_headers = true;
 $options = getopt('f', ['foregroud']);
 
 /* check if poller daemon is already running */
-exec('ps -ef | grep -v grep | grep -v "sh -c" | grep thold_daemon.php', $output);
+exec('pgrep -a php | grep thold_daemon.php', $output);
 if(sizeof($output)>=2) {
     fwrite( STDOUT, "Thold Daemon is still running\n");
     return;

--- a/thold_daemon.php
+++ b/thold_daemon.php
@@ -30,6 +30,8 @@ if (!isset($_SERVER["argv"][0]) || isset($_SERVER['REQUEST_METHOD'])  || isset($
 
 $no_http_headers = true;
 
+$options = getopt('f', ['foregroud']);
+
 /* check if poller daemon is already running */
 exec('ps -ef | grep -v grep | grep -v "sh -c" | grep thold_daemon.php', $output);
 if(sizeof($output)>=2) {
@@ -54,22 +56,24 @@ chdir('../../');
 
 fwrite(STDOUT, 'Starting Thold Daemon ... ');
 
-if(function_exists('pcntl_fork')) {
-    /* fork the current process to bring a real new daemon on the road */
-    $pid = pcntl_fork();
-    if($pid == -1) {
-        /* oha ... something went wrong :( */
-        fwrite(STDOUT, '[FAILED]' . PHP_EOL);
-        return false;
-    }elseif($pid == 0) {
-        /* the child should do nothing as long as the parent is still alive */
-    }else {
-        /* return the PID of the new child and kill the parent */
-		fwrite(STDOUT, '[OK]' . PHP_EOL);
-        return true;
-    }
-}else {
-    fwrite(STDOUT, '[WARNING] This system does not support forking.' . PHP_EOL);
+if(!isset($options['f']) && !isset($options['foreground'])) {
+	if(function_exists('pcntl_fork')) {
+		/* fork the current process to bring a real new daemon on the road */
+		$pid = pcntl_fork();
+		if($pid == -1) {
+			/* oha ... something went wrong :( */
+			fwrite(STDOUT, '[FAILED]' . PHP_EOL);
+			return false;
+		}elseif($pid == 0) {
+			/* the child should do nothing as long as the parent is still alive */
+		}else {
+			/* return the PID of the new child and kill the parent */
+			fwrite(STDOUT, '[OK]' . PHP_EOL);
+			return true;
+		}
+	}else {
+		fwrite(STDOUT, '[WARNING] This system does not support forking.' . PHP_EOL);
+	}
 }
 require_once('./include/global.php');
 require_once($config['base_path'] . '/lib/poller.php');

--- a/thold_daemon.php
+++ b/thold_daemon.php
@@ -30,7 +30,7 @@ if (!isset($_SERVER["argv"][0]) || isset($_SERVER['REQUEST_METHOD'])  || isset($
 
 $no_http_headers = true;
 
-$options = getopt('f', ['foregroud']);
+$options = getopt('f', array('foregroud'));
 
 /* check if poller daemon is already running */
 exec('pgrep -a php | grep thold_daemon.php', $output);

--- a/thold_daemon.php
+++ b/thold_daemon.php
@@ -36,7 +36,7 @@ $options = getopt('f', ['foregroud']);
 exec('pgrep -a php | grep thold_daemon.php', $output);
 if(sizeof($output)>=2) {
     fwrite( STDOUT, "Thold Daemon is still running\n");
-    return;
+    exit(1);
 }
 
 /* we are not talking to the browser */

--- a/thold_daemon.service
+++ b/thold_daemon.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Cacti Thold Daemon.
-After=mysqld.service
-Requires=mysqld.service
+After=mysql.service
+Requires=mysql.service
 AssertPathExists=<CACTIDIR>/plugins/thold/
 
 [Service]

--- a/thold_daemon.service
+++ b/thold_daemon.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Cacti Thold Daemon.
+After=mysqld.service
+Requires=mysqld.service
+AssertPathExists=<CACTIDIR>/plugins/thold/
+
+[Service]
+User=cacti
+Group=cacti
+Type=simple
+ExecStart=/usr/bin/php <CACTIDIR>/plugins/thold/thold_daemon.php -f
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hi,

We start the thold_daemon with systemd. When starting  process with systemd the process does not need to daemonize. For this we added an foreground option.

This patch includes the foreground option for the thold_daemon and a small fix to the check for running thold_daemon processes so it doesn't match vim thold_daemon.php.

It also included a example systemd unit file for thold_daemon

Best regards,

Arjan