### PR TITLE
Baseline Settings not shown on the Thold settings tab

### DIFF
--- a/thold_functions.php
+++ b/thold_functions.php
@@ -2772,7 +2772,7 @@ function thold_format_name($template, $local_graph_id, $local_data_id, $data_sou
 function get_reference_types($rra = 0, $step = 300) {
 	global $config, $timearray;
 
-	include_once($config['base_path'] . '/plugins/thold/includes/arrays.php');
+	include($config['base_path'] . '/plugins/thold/includes/arrays.php');
 
 	$rra_steps = db_fetch_assoc('SELECT DISTINCT dspr.steps
 		FROM data_template_data AS dtd


### PR DESCRIPTION
The arrays.php is not read in correctly leaving the timearray array empty, therefore not showing up correctly on the settings tab.

Not sure why this happens though as the code looks right otherwise.  Changing the include_once to include fixes this by making sure to always read in the arrays.php file