### PR TITLE
Now shows counts of notification list usage on front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The thold plugin has been in development for well over a decade with increasing 
 * issue#145: Cacti turning Thold off
 * issue#153: Threshold Template "Operator Notes" Variable not Recognized
 * issue#154: Removed Devices are not pruned to thold tables
+* feature: Now shows counts of notification list usage on front page
 * feature: First attempt of thresholding by data collector.  Note that if you are using the thold daemon, you will need to run on each data collector.
 * feature: Report Thold Daemon Runtime with Millisecond precision.
 * feature: Prepare for new Cacti 1.2 feature for storing RRDfiles on remote storage


### PR DESCRIPTION
Now shows the count of devices and warning/alert for thresholds/threshold templates plus links through to hidden tabs which most people miss.

Added this to make life easier when working in conjunction with my new notification list importer

![image](https://user-images.githubusercontent.com/9052188/36506351-4ad5b5f8-174e-11e8-9839-ec1b3fd99d25.png)
