### PR TITLE
Issue #167: Separate filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The thold plugin has been in development for well over a decade with increasing 
 * issue#155: Autocreate now failing due to recent changes
 * issue#157: Operator Notes are not propagated during Template updates
 * issue#160: RPN Expressions not handling ifSpeed and ifHighSpeed replacement
+* issue#167: Separate filter for management and monitoring tabs
 * feature: Now shows counts of notification list usage on front page
 * feature: First attempt of thresholding by data collector.  Note that if you are using the thold daemon, you will need to run on each data collector.
 * feature: Report Thold Daemon Runtime with Millisecond precision.

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -204,7 +204,20 @@ function thold_config_settings () {
 			'default' => ''
 		),
 		'thold_filter_default' => array(
-			'friendly_name' => __('Default Status', 'thold'),
+			'friendly_name' => __('Default Management Status', 'thold'),
+			'description' => __('Default Threshold management filter status.', 'thold'),
+			'method' => 'drop_array',
+			'array' => array(
+				'-1' => __('Any', 'thold'),
+				'0'  => __('Disabled', 'thold'),
+				'2'  => __('Enabled', 'thold'),
+				'1'  => __('Breached', 'thold'),
+				'3'  => __('Triggered', 'thold')
+			),
+			'default' => -1
+		),
+		'thold_monitor_default' => array(
+			'friendly_name' => __('Default Monitor Status', 'thold'),
 			'description' => __('Default Threshold Tab filter status.', 'thold'),
 			'method' => 'drop_array',
 			'array' => array(
@@ -214,7 +227,7 @@ function thold_config_settings () {
 				'1'  => __('Breached', 'thold'),
 				'3'  => __('Triggered', 'thold')
 			),
-			'default' => 20
+			'default' => -1
 		),
 		'thold_empty_if_speed_default' => array(
 			'friendly_name' => __('Empty ifHighSpeed Default', 'thold'),

--- a/thold_graph.php
+++ b/thold_graph.php
@@ -263,7 +263,7 @@ function tholds() {
 		'status' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'pageset' => true,
-			'default' => read_config_option('thold_filter_default')
+			'default' => read_config_option('thold_monitor_default')
 			)
 	);
 


### PR DESCRIPTION
This feature enhancement creates separate filter settings for the management and monitoring tabs which means you can have monitor set to Breached whilst your management list defaults to All.  It also fixes the issue where the default value was 20 rather than -1 for all.