### PR TITLE
RPN Comparsion operator's results are wrong

### DIFF
--- a/thold_functions.php
+++ b/thold_functions.php
@@ -325,8 +325,8 @@ function thold_expression_boolean_rpn($operator, &$stack) {
 			array_push($stack, $v2);
 		}
 	} else {
-		$v1 = thold_expression_rpn_pop($stack);
 		$v2 = thold_expression_rpn_pop($stack);
+		$v1 = thold_expression_rpn_pop($stack);
 
 		/* deal with unknown or infinite data */
 		if (($v1 == 'INF' || $v2 == 'INF') ||


### PR DESCRIPTION
Variable 1 and variable 2 in the function thold_expression_compare_rpn need to swap, otherwise the result of LT, LE, GT, GE will be wrong.