### PR TITLE
FIX: Thold thold_graphs_action_prepare() errors on PHP >= 7.1

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -983,7 +983,7 @@ function thold_graphs_action_prepare($save) {
 		 */
 		$found_list = '';
 		$not_found  = '';
-		$template_ids = '';
+		$template_ids = [];             // Fix: As of PHP 7.1.0, applying the empty index operator on a string throws a fatal error. Formerly, the string was silently converted to an array.
 
 		if (cacti_sizeof($save['graph_array'])) {
 			foreach($save['graph_array'] as $item) {

--- a/thold_functions.php
+++ b/thold_functions.php
@@ -3050,21 +3050,21 @@ function thold_command_execution(&$thold_data, &$h, $breach_up, $breach_down, $b
 			$cmd = thold_replace_threshold_tags($thold_data['trigger_cmd_high'], $thold_data, $h, $thold_data['lastread'], $thold_data['local_graph_id'], $data_source_name);
 			$cmd = thold_expand_string($thold_data, $cmd);
 
-			exec($thold_data['trigger_cmd_high'], $output, $return);
+			exec($cmd, $output, $return);
 
 			$command_executed = true;
 		} elseif ($breach_down && $thold_data['trigger_cmd_low'] != '') {
 			$cmd = thold_replace_threshold_tags($thold_data['trigger_cmd_low'], $thold_data, $h, $thold_data['lastread'], $thold_data['local_graph_id'], $data_source_name);
 			$cmd = thold_expand_string($thold_data, $cmd);
 
-			exec($thold_data['trigger_cmd_low'], $output, $return);
+			exec($cmd, $output, $return);
 
 			$command_executed = true;
 		} elseif ($breach_norm && $thold_data['trigger_cmd_norm'] != '') {
 			$cmd = thold_replace_threshold_tags($thold_data['trigger_cmd_norm'], $thold_data, $h, $thold_data['lastread'], $thold_data['local_graph_id'], $data_source_name);
 			$cmd = thold_expand_string($thold_data, $cmd);
 
-			exec($thold_data['trigger_cmd_norm'], $output, $return);
+			exec($cmd, $output, $return);
 
 			$command_executed = true;
 		}

--- a/thold_functions.php
+++ b/thold_functions.php
@@ -3092,10 +3092,14 @@ function thold_replace_threshold_tags($text, &$thold, &$h, $currentval, $local_g
 
 	$httpurl    = read_config_option('base_url');
 
+	// Compile the subject
+        $subject = 'ALERT: ' . $thold['name_cache'] . ($thold_show_datasource ? ' [' . $thold['data_source_name'] . ']' : '') . ' ' . ($ra ? 'is still' : 'went') . ' ' . ($breach_up ? 'above' : 'below') . ' threshold of ' . ($breach_up ? $thold['thold_hi'] : $thold['thold_low']) . ' with ' . $thold['lastread'];
+
 	// Do some replacement of variables
 	$text = str_replace('<DESCRIPTION>',   $h['description'], $text);
 	$text = str_replace('<HOSTNAME>',      $h['hostname'], $text);
 	$text = str_replace('<GRAPHID>',       $local_graph_id, $text);
+	$text = str_replace('<SUBJECT>',       $subject, $text);
 
 	$text = str_replace('<CURRENTVALUE>',  $currentval, $text);
 	$text = str_replace('<THRESHOLDNAME>', $thold['name_cache'], $text);


### PR DESCRIPTION
Fix for error in thold_graphs_action_prepare() on PHP versions >= 7.1

As of PHP 7.1.0, applying the empty index operator on a string throws a fatal error.

PHP Fatal error:  Uncaught Error: [] operator not supported for strings in /usr/share/cacti/plugins/thold/setup.php:966