### PR TITLE
Increase trigger_cmd_* fields to 512 bytes

### DIFF
--- a/includes/database.php
+++ b/includes/database.php
@@ -948,25 +948,31 @@ function thold_upgrade_database($force = false) {
 		db_execute('ALTER TABLE thold_data MODIFY COLUMN exempt char(3) NOT NULL default ""');
 		db_execute('ALTER TABLE thold_data MODIFY COLUMN data_type int(12) NOT NULL default "0"');
 		db_execute('ALTER TABLE thold_data MODIFY COLUMN notify_extra varchar(512) default ""');
+		db_execute('ALTER TABLE thold_data MODIFY COLUMN trigger_cmd_high varchar(512) NOT NULL default ""');
+		db_execute('ALTER TABLE thold_data MODIFY COLUMN trigger_cmd_low varchar(512) NOT NULL default ""');
+		db_execute('ALTER TABLE thold_data MODIFY COLUMN trigger_cmd_norm varchar(512) NOT NULL default ""');
+		db_execute('ALTER TABLE thold_template MODIFY COLUMN trigger_cmd_high varchar(512) NOT NULL default ""');
+		db_execute('ALTER TABLE thold_template MODIFY COLUMN trigger_cmd_low varchar(512) NOT NULL default ""');
+		db_execute('ALTER TABLE thold_template MODIFY COLUMN trigger_cmd_norm varchar(512) NOT NULL default ""');
 
 		// Trigger commands
 		db_add_column('thold_data', array(
 			'name'    => 'trigger_cmd_high',
-			'type'    => 'varchar(255)',
+			'type'    => 'varchar(512)',
 			'NULL'    => false,
 			'default' => '',
 			'after'   => 'email_body_warn'));
 
 		db_add_column('thold_data', array(
 			'name'    => 'trigger_cmd_low',
-			'type'    => 'varchar(255)',
+			'type'    => 'varchar(512)',
 			'NULL'    => false,
 			'default' => '',
 			'after'   => 'trigger_cmd_high'));
 
 		db_add_column('thold_data', array(
 			'name'    => 'trigger_cmd_norm',
-			'type'    => 'varchar(255)',
+			'type'    => 'varchar(512)',
 			'NULL'    => false,
 			'default' => '',
 			'after'   => 'trigger_cmd_low'));
@@ -1023,21 +1029,21 @@ function thold_upgrade_database($force = false) {
 		// Trigger commands
 		db_add_column('thold_template', array(
 			'name' => 'trigger_cmd_high',
-			'type'=> 'varchar(255)',
+			'type'=> 'varchar(512)',
 			'NULL' => false,
 			'default' => '',
 			'after' => 'email_body_warn'));
 
 		db_add_column('thold_template', array(
 			'name' => 'trigger_cmd_low',
-			'type'=> 'varchar(255)',
+			'type'=> 'varchar(512)',
 			'NULL' => false,
 			'default' => '',
 			'after' => 'trigger_cmd_high'));
 
 		db_add_column('thold_template', array(
 			'name' => 'trigger_cmd_norm',
-			'type'=> 'varchar(255)',
+			'type'=> 'varchar(512)',
 			'NULL' => false,
 			'default' => '',
 			'after' => 'trigger_cmd_low'));


### PR DESCRIPTION
Hi TheWitness,

Sorry for all the pull requests and issues, been doing some work to integrate plugin_thold with our event management systems, hope I'm not bugging you too much...

The field size for the the trigger_cmd_hi etc. etc. were set to 255, which is a bit small for a command line that includes all the expandable fields.

As an example even cutting the path name down to /bin and moving from --option to -c single character, I still can't bring the overall size below 255. This is 309 characters for example:

/bin/tholdApiCall.php send-iface-event -a low -b "|query_ifDescr|" -c "|query_ifAlias|" -d "|query_ifIP|" -e "<DESCRIPTION>" -h "<HOSTNAME>" -t "<TIME>" -g "<GRAPHID>" -v "<CURRENTVALUE>" -k "<THRESHOLDNAME>" -m "<DSNAME>" -s "<SUBJECT>" -h "<HI>" -l "<LOW>" -r "<DURATION>" -u "<TRIGGER>"  -v "<DATE_RFC822>"

Thanks!
Allan.