### PR TITLE
Fix search thold - wrong sql_where condition

### DIFF
--- a/thold.php
+++ b/thold.php
@@ -581,7 +581,7 @@ function list_tholds() {
 	}
 
 	if (strlen(get_request_var('filter'))) {
-		$sql_where .= ($sql_where == '' ? ' AND': '(') . " td.name_cache LIKE '%" . get_request_var('filter') . "%'";
+		$sql_where .= ($sql_where == '' ? '(' : ' AND') . " td.name_cache LIKE '%" . get_request_var('filter') . "%'";
 	}
 
 	if ($statefilter != '') {


### PR DESCRIPTION
your code generates wrong SQL query:
 ... **WHERE AND** td.name_cache LIKE '%search_text%' ...