### PR TITLE
Fixed:  deprecated curly braces for array index in PHP 7.4

### DIFF
--- a/notify_lists.php
+++ b/notify_lists.php
@@ -501,7 +501,7 @@ function form_actions() {
 
 		form_start('notify_lists.php');
 
-		html_start_box($actions{get_request_var('drp_action')} . " $list_name", '80%', false, '3', 'center', '');
+		html_start_box($actions[get_request_var('drp_action')] . " $list_name", '80%', false, '3', 'center', '');
 
 		if (cacti_sizeof($array)) {
 			if (get_request_var('drp_action') == '1') { /* delete */
@@ -708,7 +708,7 @@ function form_actions() {
 
 		form_start('notify_lists.php');
 
-		html_start_box($assoc_actions{get_request_var('drp_action')} . ' Device(s)', '80%', false, '3', 'center', '');
+		html_start_box($assoc_actions[get_request_var('drp_action')] . ' Device(s)', '80%', false, '3', 'center', '');
 
 		if (cacti_sizeof($array)) {
 			if (get_request_var('drp_action') == '1') { /* associate */


### PR DESCRIPTION
Same fix as Cacti/cacti#2859