### PR TITLE
Add new per host config thold_failure_count

### DIFF
--- a/includes/database.php
+++ b/includes/database.php
@@ -459,6 +459,14 @@ function thold_upgrade_database($force = false) {
 			'NULL'     => true,
 			'after'    => 'thold_send_email'));
 
+		api_plugin_db_add_column('thold', 'host', array(
+			'name'     => 'thold_failure_count',
+			'type'     => 'int(10)',
+			'unsigned' => true,
+			'NULL'     => false,
+			'default'  => '0',
+			'after'    => 'thold_host_email'));
+			
 		db_add_column('thold_data', array(
 			'name'     => 'notify_warning',
 			'type'     => 'int(10)',
@@ -1587,6 +1595,7 @@ function thold_setup_database() {
 
 	api_plugin_db_add_column('thold', 'host', array('name' => 'thold_send_email', 'type' => 'int(10)', 'NULL' => false, 'default' => '1', 'after' => 'disabled'));
 	api_plugin_db_add_column('thold', 'host', array('name' => 'thold_host_email', 'type' => 'int(10)', 'NULL' => true, 'after' => 'thold_send_email'));
+	api_plugin_db_add_column('thold', 'host', array('name' => 'thold_failure_count', 'type' => 'int(10)', 'NULL' => false, 'default' => '0', 'after' => 'thold_host_email'));
 
 	$data = array();
 	$data['columns'][] = array('name' => 'id', 'type' => 'int(12)', 'NULL' => false, 'unsigned' => true, 'auto_increment' => true);

--- a/includes/polling.php
+++ b/includes/polling.php
@@ -344,7 +344,7 @@ function thold_poller_output(&$rrd_update_array) {
 		dtd.rrd_step, dtr.rrd_maximum
 		FROM thold_data AS td
 		LEFT JOIN data_template_rrd AS dtr
-		ON (dtr.id = td.data_template_rrd_id)
+		ON dtr.id = td.data_template_rrd_id
 		LEFT JOIN data_template_data AS dtd
 		ON dtd.local_data_id = td.local_data_id
 		WHERE dtr.data_source_name!=''
@@ -706,7 +706,7 @@ function thold_update_host_status() {
 			FROM host
 			WHERE disabled=""
 			AND status = ?
-			AND status_event_count = if(thold_failure_count>0,thold_failure_count, ? )',
+			AND status_event_count = IF(thold_failure_count > 0, thold_failure_count, ?)',
 			array(HOST_DOWN, $ping_failure_count));
 	}
 
@@ -807,7 +807,7 @@ function thold_update_host_status() {
 			WHERE disabled = ""
 			AND poller_id = ?
 			AND ((status != ? AND status != ?)
-			OR (status = ? AND status_event_count >= if(thold_failure_count>0,thold_failure_count, ? ))) ',
+			OR (status = ? AND status_event_count >= IF(thold_failure_count > 0, thold_failure_count, ?))) ',
 			array($config['poller_id'], HOST_UP,HOST_DOWN,HOST_DOWN, $ping_failure_count));
 	} else {
 		db_execute('TRUNCATE plugin_thold_host_failed');
@@ -816,7 +816,7 @@ function thold_update_host_status() {
 			FROM host
 			WHERE disabled = ""
 			AND ((status != ? AND status != ?)
-			OR (status = ? AND status_event_count >= if(thold_failure_count>0,thold_failure_count, ? ))) ',
+			OR (status = ? AND status_event_count >= IF(thold_failure_count > 0, thold_failure_count, ?))) ',
 			array(HOST_UP,HOST_DOWN,HOST_DOWN, $ping_failure_count));
 	}
 

--- a/includes/polling.php
+++ b/includes/polling.php
@@ -698,7 +698,7 @@ function thold_update_host_status() {
 			FROM host
 			WHERE disabled=""
 			AND status = ?
-			AND status_event_count = IF(thold_failure_count > 0,thold_failure_count, ?)
+			AND status_event_count = IF(thold_failure_count > 0, thold_failure_count, ?)
 			AND poller_id = ?',
 			array(HOST_DOWN, $ping_failure_count, $config['poller_id']));
 	} else {

--- a/includes/polling.php
+++ b/includes/polling.php
@@ -698,7 +698,7 @@ function thold_update_host_status() {
 			FROM host
 			WHERE disabled=""
 			AND status = ?
-			AND status_event_count = if(thold_failure_count>0,thold_failure_count, ? )
+			AND status_event_count = IF(thold_failure_count > 0,thold_failure_count, ?)
 			AND poller_id = ?',
 			array(HOST_DOWN, $ping_failure_count, $config['poller_id']));
 	} else {

--- a/includes/polling.php
+++ b/includes/polling.php
@@ -808,7 +808,7 @@ function thold_update_host_status() {
 			AND poller_id = ?
 			AND ((status != ? AND status != ?)
 			OR (status = ? AND status_event_count >= IF(thold_failure_count > 0, thold_failure_count, ?))) ',
-			array($config['poller_id'], HOST_UP,HOST_DOWN,HOST_DOWN, $ping_failure_count));
+			array($config['poller_id'], HOST_UP, HOST_DOWN, HOST_DOWN, $ping_failure_count));
 	} else {
 		db_execute('TRUNCATE plugin_thold_host_failed');
 
@@ -817,7 +817,7 @@ function thold_update_host_status() {
 			WHERE disabled = ""
 			AND ((status != ? AND status != ?)
 			OR (status = ? AND status_event_count >= IF(thold_failure_count > 0, thold_failure_count, ?))) ',
-			array(HOST_UP,HOST_DOWN,HOST_DOWN, $ping_failure_count));
+			array(HOST_UP, HOST_DOWN, HOST_DOWN, $ping_failure_count));
 	}
 
 	$failed_ids = '';

--- a/includes/polling.php
+++ b/includes/polling.php
@@ -820,9 +820,9 @@ function thold_update_host_status() {
 			array(HOST_UP, HOST_DOWN, HOST_DOWN, $ping_failure_count));
 	}
 
-	$failed_ids = '';
+	if (cacti_sizeof($hosts)) {
+		$failed_ids = '';
 
-  if (cacti_sizeof($hosts)) {
 		foreach ($hosts as $host) {
 			//hosts in recovery status record only if they was in failed status
 			if (($host['status'] != HOST_RECOVERING) OR ($host['status'] == HOST_RECOVERING AND (array_search($host['id'], array_column($failed, 'host_id')) !== FALSE))) {
@@ -830,17 +830,17 @@ function thold_update_host_status() {
 					continue;
 				}
 
-        $failed_ids .= ($failed_ids != '' ? '), (':'(') . $host['id'];
+				$failed_ids .= ($failed_ids != '' ? '), (':'(') . $host['id'];
 			}
 		}
 
-    $failed_ids .= $failed_ids != '' ? ')':'';
+		$failed_ids .= $failed_ids != '' ? ')':'';
 
-    if ($failed_ids != '') {
-		  db_execute("INSERT INTO plugin_thold_host_failed
-  			(host_id)
-	  		VALUES $failed_ids");
-    }
+ 		if ($failed_ids != '') {
+			db_execute("INSERT INTO plugin_thold_host_failed
+				(host_id)
+				VALUES $failed_ids");
+		}
 	}
 
 	return $total_hosts;

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -181,6 +181,16 @@ function thold_config_form() {
 				'default' => '',
 				'none_value' => 'None'
 			);
+			$fields_host_edit3['thold_failure_count'] = array(
+				'friendly_name' => __('Host Failure Count', 'thold'),
+				'description' => __('The number of polling intervals at this host must be down before Thold logging an error and reporting host as down. Default is 0 (not use it and use config[ping_failure_count])', 'thold'),
+				'method' => 'textbox',
+				'value' => '|arg1:thold_failure_count|',
+				'default' => '0',
+				'max_length' => 5,
+				'size' => 15,
+				'none_value' => 'None',
+			);			
 		}
 	}
 

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -183,13 +183,18 @@ function thold_config_form() {
 			);
 			$fields_host_edit3['thold_failure_count'] = array(
 				'friendly_name' => __('Host Failure Count', 'thold'),
-				'description' => __('The number of polling intervals at this host must be down before Thold logging an error and reporting host as down. Default is 0 (not use it and use config[ping_failure_count])', 'thold'),
-				'method' => 'textbox',
+				'description' => __('The number of Polling Intervals at this Host must be Down before Thold logging an error and reporting Host as Down. Default is 0 (use Cacti setting)', 'thold'),
+				'method' => 'drop_array',
 				'value' => '|arg1:thold_failure_count|',
 				'default' => '0',
-				'max_length' => 5,
-				'size' => 15,
-				'none_value' => 'None',
+				'array' => array(
+					0 => __('Use Cacti Setting', 'thold'),
+					1 => __('%d Polling Interval', 1, 'thold'),
+					2 => __('%d Polling Intervals', 2, 'thold'),
+					3 => __('%d Polling Intervals', 3, 'thold'),
+					4 => __('%d Polling Intervals', 4, 'thold'),
+					5 => __('%d Polling Intervals', 5, 'thold'),
+				)
 			);			
 		}
 	}

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -181,6 +181,7 @@ function thold_config_form() {
 				'default' => '',
 				'none_value' => 'None'
 			);
+
 			$fields_host_edit3['thold_failure_count'] = array(
 				'friendly_name' => __('Host Failure Count', 'thold'),
 				'description' => __('The number of Polling Intervals at this Host must be Down before Thold logging an error and reporting Host as Down. Default is 0 (use Cacti setting)', 'thold'),


### PR DESCRIPTION
Some devices lost network for 1-2 minutes and Thold will alert for this. That config add ability to set failure_count per devices. Main poller will show host is down and up, but Thold will alert only if host will be down count of pollers run >= host`s thold_failure_count.