### PR TITLE
Fix: Create threshold from templates fail with multiple data template ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * issue#463: php error - undefined index dnotes 
 
+* issue#467: The thold cdef processing function does not handle non-numeric data correctly
+
 * issue#474: Create threshold from templates fail with multiple data template ids
 
 * feature#469: use thold template name as filename for single export

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -566,7 +566,7 @@
 * feature: Moving away from direct use of GET, REQUEST, and POST variables for
   security
 
-* feature: Rename several legacy database columns to match Cacti's default
+* feature: Rename several legacy database columns to match Cactis default
   schema, making the thold code much more readable
 
 * feature: complete audit and rewrite of several functions addressing:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -834,7 +834,7 @@
 
 * bug: Fix for threshold template data propagating to an incorrect threshold
 
-* feature: Added Email Address field to User's Profiles
+* feature: Added Email Address field to Users Profiles
 
 * feature: Added ability to select a user to alert for a threshold instead of
   having to type in their email address
@@ -1028,7 +1028,7 @@
 
 --- 0.2.0 ---
 
-* feature: Auto-create the database if it doesn't exist
+* feature: Auto-create the database if it doesnt exist
 
 * bug: Better sorting on threshold tables
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 --- 1.5.3 ---
 
-* issue#474: Create threshold from templates fail with multiple data template ids
-
 * issue#463: php error - undefined index dnotes 
+
+* issue#474: Create threshold from templates fail with multiple data template ids
 
 * feature#469: use thold template name as filename for single export
 
@@ -128,7 +128,7 @@
 
 * issue#358: Downtime message is only calculated when SNMP is in use
 
-* issue#361: Thresholds are not applying CDEF's correctly
+* issue#361: Thresholds are not applying CDEFs correctly
 
 * issue#364: Thold 1.3.2 A non-numeric value encountered in thold_functions.php
 
@@ -288,7 +288,7 @@
 
 * issue#320: Thold Graph broken when name include single quote
 
-* issue#322: Standalone thresholds based on graph with serveral DS don't work
+* issue#322: Standalone thresholds based on graph with serveral DS dont work
   for DS after the 1st one...
 
 * issue#323: "Associated Graph (Graphs using this RRD)" field not including all
@@ -307,7 +307,7 @@
 * issue#334: Undefined index: data_source_name in file: thold_functions.php
 
 * issue#335: Undefined index: desc in file:
-  /opt/IBM/cacti/plugins/thold/thold_functions.php
+  CACTI_TOP/plugins/thold/thold_functions.php
 
 * issue#336: cacti 1.2.4 and THOLD 1.2.x check_all_thresholds error
 
@@ -510,7 +510,7 @@
 
 * issue#91: Search filter not working from Thold Management
 
-* issue#93: Thold ID's when auto created are NOT in sequential order
+* issue#93: Thold IDs when auto created are NOT in sequential order
 
 * issue#94: `<DOWNTIME>` not processed properly when the value has never changed
 
@@ -572,7 +572,7 @@
 
 --- 0.6 ---
 
-* feature: Reduce influence upon Cacti's poller runtime to a minimum by
+* feature: Reduce influence upon Cactis poller runtime to a minimum by
   introducing a Thold daemon (also allows distribution)
 
 * feature: Support of SNMP traps and informs ( requires the CACTI SNMPAgent
@@ -601,7 +601,7 @@
 
 * bug: Restoral Emails not working in all cases
 
-* bug: When polling returns non-numeric data,  don't return false LOW Alerts
+* bug: When polling returns non-numeric data,  dont return false LOW Alerts
 
 * bug: Fix time based Warnings
 
@@ -639,7 +639,7 @@
 
 * bug: Fix several GUI and polling issues
 
-* bug: Don't alert on blank data output
+* bug: Dont alert on blank data output
 
 * bug: Remove old ununsed variables
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 --- 1.5.3 ---
 
-* issue#463: php error - undefined index dnotes 
+* issue#474: Create threshold from templates fail with multiple data template ids
 
-* issue#467: The thold cdef processing function does not handle non-numeric data correctly
+* issue#463: php error - undefined index dnotes 
 
 * feature#469: use thold template name as filename for single export
 
@@ -128,7 +128,7 @@
 
 * issue#358: Downtime message is only calculated when SNMP is in use
 
-* issue#361: Thresholds are not applying CDEFs correctly
+* issue#361: Thresholds are not applying CDEF's correctly
 
 * issue#364: Thold 1.3.2 A non-numeric value encountered in thold_functions.php
 
@@ -288,7 +288,7 @@
 
 * issue#320: Thold Graph broken when name include single quote
 
-* issue#322: Standalone thresholds based on graph with serveral DS dont work
+* issue#322: Standalone thresholds based on graph with serveral DS don't work
   for DS after the 1st one...
 
 * issue#323: "Associated Graph (Graphs using this RRD)" field not including all
@@ -307,7 +307,7 @@
 * issue#334: Undefined index: data_source_name in file: thold_functions.php
 
 * issue#335: Undefined index: desc in file:
-  CACTI_TOP/plugins/thold/thold_functions.php
+  /opt/IBM/cacti/plugins/thold/thold_functions.php
 
 * issue#336: cacti 1.2.4 and THOLD 1.2.x check_all_thresholds error
 
@@ -510,7 +510,7 @@
 
 * issue#91: Search filter not working from Thold Management
 
-* issue#93: Thold IDs when auto created are NOT in sequential order
+* issue#93: Thold ID's when auto created are NOT in sequential order
 
 * issue#94: `<DOWNTIME>` not processed properly when the value has never changed
 
@@ -564,7 +564,7 @@
 * feature: Moving away from direct use of GET, REQUEST, and POST variables for
   security
 
-* feature: Rename several legacy database columns to match Cactis default
+* feature: Rename several legacy database columns to match Cacti's default
   schema, making the thold code much more readable
 
 * feature: complete audit and rewrite of several functions addressing:
@@ -572,7 +572,7 @@
 
 --- 0.6 ---
 
-* feature: Reduce influence upon Cactis poller runtime to a minimum by
+* feature: Reduce influence upon Cacti's poller runtime to a minimum by
   introducing a Thold daemon (also allows distribution)
 
 * feature: Support of SNMP traps and informs ( requires the CACTI SNMPAgent
@@ -601,7 +601,7 @@
 
 * bug: Restoral Emails not working in all cases
 
-* bug: When polling returns non-numeric data,  dont return false LOW Alerts
+* bug: When polling returns non-numeric data,  don't return false LOW Alerts
 
 * bug: Fix time based Warnings
 
@@ -639,7 +639,7 @@
 
 * bug: Fix several GUI and polling issues
 
-* bug: Dont alert on blank data output
+* bug: Don't alert on blank data output
 
 * bug: Remove old ununsed variables
 
@@ -832,7 +832,7 @@
 
 * bug: Fix for threshold template data propagating to an incorrect threshold
 
-* feature: Added Email Address field to Users Profiles
+* feature: Added Email Address field to User's Profiles
 
 * feature: Added ability to select a user to alert for a threshold instead of
   having to type in their email address
@@ -1026,7 +1026,7 @@
 
 --- 0.2.0 ---
 
-* feature: Auto-create the database if it doesnt exist
+* feature: Auto-create the database if it doesn't exist
 
 * bug: Better sorting on threshold tables
 

--- a/setup.php
+++ b/setup.php
@@ -1078,8 +1078,8 @@ function thold_graphs_action_prepare($save) {
 
 				if (cacti_sizeof($data_template_ids)) {
 					foreach ($data_template_ids as $i => $data_template_rec) {
-						$data_template_id = isset($data_template_rec['data_template_id']) ? $data_template_rec['data_template_id'] : '';
-						$not_found.= "<li> data_template_id = $data_template_id </li>";
+						$data_template_id = $data_template_rec['data_template_id']
+
 						$templates = db_fetch_assoc_prepared('SELECT id
 							FROM thold_template
 							WHERE data_template_id = ?',

--- a/setup.php
+++ b/setup.php
@@ -1083,7 +1083,7 @@ function thold_graphs_action_prepare($save) {
 						FROM thold_template
 						WHERE data_template_id = ?',
 						array($data_template_id));
-					
+
 					if (cacti_sizeof($templates)) {
 						$item_found = true;
 						$template_ids[] = $data_template_id;

--- a/setup.php
+++ b/setup.php
@@ -1076,17 +1076,19 @@ function thold_graphs_action_prepare($save) {
 					WHERE gl.id = ?',
 					array($item));
 
-				foreach ($data_template_ids as $i => $data_template_rec) {
-					$data_template_id = isset($data_template_rec['data_template_id']) ? $data_template_rec['data_template_id'] : '';
-					$not_found.= "<li> data_template_id = $data_template_id </li>";
-					$templates = db_fetch_assoc_prepared('SELECT id
-						FROM thold_template
-						WHERE data_template_id = ?',
-						array($data_template_id));
+				if (cacti_sizeof($data_template_ids)) {
+					foreach ($data_template_ids as $i => $data_template_rec) {
+						$data_template_id = isset($data_template_rec['data_template_id']) ? $data_template_rec['data_template_id'] : '';
+						$not_found.= "<li> data_template_id = $data_template_id </li>";
+						$templates = db_fetch_assoc_prepared('SELECT id
+							FROM thold_template
+							WHERE data_template_id = ?',
+							array($data_template_id));
 
-					if (cacti_sizeof($templates)) {
-						$item_found = true;
-						$template_ids[] = $data_template_id;
+						if (cacti_sizeof($templates)) {
+							$item_found = true;
+							$template_ids[] = $data_template_id;
+						}
 					}
 				}
 				

--- a/setup.php
+++ b/setup.php
@@ -1075,7 +1075,7 @@ function thold_graphs_action_prepare($save) {
 					ON gl.id=gti.local_graph_id
 					WHERE gl.id = ?',
 					array($item));
-				
+
 				foreach ($data_template_ids as $i => $data_template_rec) {
 					$data_template_id = isset($data_template_rec['data_template_id']) ? $data_template_rec['data_template_id'] : '';
 					$not_found.= "<li> data_template_id = $data_template_id </li>";

--- a/setup.php
+++ b/setup.php
@@ -1068,26 +1068,26 @@ function thold_graphs_action_prepare($save) {
 			foreach($save['graph_array'] as $item) {
 				$item_found = false;
 				$data_template_ids = db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_template_id
-                                         FROM data_template_rrd AS dtr
-                                         LEFT JOIN graph_templates_item AS gti
-                                         ON gti.task_item_id=dtr.id
-                                         LEFT JOIN graph_local AS gl
-                                         ON gl.id=gti.local_graph_id
-                                         WHERE gl.id = ?',
-                                        array($item));
+					FROM data_template_rrd AS dtr
+					LEFT JOIN graph_templates_item AS gti
+					ON gti.task_item_id=dtr.id
+					LEFT JOIN graph_local AS gl
+					ON gl.id=gti.local_graph_id
+					WHERE gl.id = ?',
+					array($item));
 				
 				foreach ($data_template_ids as $i => $data_template_rec) {
 					$data_template_id = isset($data_template_rec['data_template_id']) ? $data_template_rec['data_template_id'] : '';
 					$not_found.= "<li> data_template_id = $data_template_id </li>";
 					$templates = db_fetch_assoc_prepared('SELECT id
-                                                FROM thold_template
-                                                WHERE data_template_id = ?',
-                                                array($data_template_id));
+						FROM thold_template
+						WHERE data_template_id = ?',
+						array($data_template_id));
 					
 					if (cacti_sizeof($templates)) {
 						$item_found = true;
-                                                $template_ids[] = $data_template_id;
-                                        }
+						$template_ids[] = $data_template_id;
+					}
 				}
 				
 				if (!$item_found) {

--- a/setup.php
+++ b/setup.php
@@ -1066,28 +1066,31 @@ function thold_graphs_action_prepare($save) {
 
 		if (cacti_sizeof($save['graph_array'])) {
 			foreach($save['graph_array'] as $item) {
-				$data_template_id = db_fetch_cell_prepared('SELECT DISTINCT dtr.data_template_id
-					 FROM data_template_rrd AS dtr
-					 LEFT JOIN graph_templates_item AS gti
-					 ON gti.task_item_id=dtr.id
-					 LEFT JOIN graph_local AS gl
-					 ON gl.id=gti.local_graph_id
-					 WHERE gl.id = ?',
-					array($item));
-
-				if ($data_template_id != '') {
+				$item_found = false;
+				$data_template_ids = db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_template_id
+                                         FROM data_template_rrd AS dtr
+                                         LEFT JOIN graph_templates_item AS gti
+                                         ON gti.task_item_id=dtr.id
+                                         LEFT JOIN graph_local AS gl
+                                         ON gl.id=gti.local_graph_id
+                                         WHERE gl.id = ?',
+                                        array($item));
+				
+				foreach ($data_template_ids as $i => $data_template_rec) {
+					$data_template_id = isset($data_template_rec['data_template_id']) ? $data_template_rec['data_template_id'] : '';
+					$not_found.= "<li> data_template_id = $data_template_id </li>";
 					$templates = db_fetch_assoc_prepared('SELECT id
-						FROM thold_template
-						WHERE data_template_id = ?',
-						array($data_template_id));
-
+                                                FROM thold_template
+                                                WHERE data_template_id = ?',
+                                                array($data_template_id));
+					
 					if (cacti_sizeof($templates)) {
-						$found_list .= '<li>' . html_escape(get_graph_title($item)) . '</li>';
-						$template_ids[] = $data_template_id;
-					} else {
-						$not_found .= '<li>' . html_escape(get_graph_title($item)) . '</li>';
-					}
-				} else {
+						$item_found = true;
+                                                $template_ids[] = $data_template_id;
+                                        }
+				}
+				
+				if (!$item_found) {
 					$not_found .= '<li>' . html_escape(get_graph_title($item)) . '</li>';
 				}
 			}


### PR DESCRIPTION
This PR is to fix an issue where thresholds can't be created on graphs with multiple data template IDs.

An example is a graph with id ```4227``` that I have for tracking UPS runtime, voltage and charge with the values from three separate data templates:

```
MariaDB [cacti]> SELECT DISTINCT dtr.data_template_id
    ->                                          FROM data_template_rrd AS dtr
    ->                                          LEFT JOIN graph_templates_item AS gti
    ->                                          ON gti.task_item_id=dtr.id
    ->                                          LEFT JOIN graph_local AS gl
    ->                                          ON gl.id=gti.local_graph_id
    ->                                          WHERE gl.id = 4227;
+------------------+
| data_template_id |
+------------------+
|               36 |
|               37 |
|               38 |
+------------------+
3 rows in set (0.005 sec)
```

The threshold I'm trying to create is for data_template_id ```38```, but as the current code is using  ```db_fetch_cell_prepared``` it only returns the first value leading to ```The following Graphs have no Threshold Templates associated with them```.