### PR TITLE
Fixed: incorrect function name for cacti develop branch

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -1437,8 +1437,9 @@ function thold_device_template_top() {
 	}
 }
 
-function thold_hook_device_autocreate($host_id) {
+function thold_device_autocreate($host_id) {
 	autocreate($host_id);
+	return $host_id;
 }
 
 function thold_create_graph_thold($save) {


### PR DESCRIPTION
Beside https://github.com/Cacti/cacti/commit/ab69a59621667bdd4bf75e18f447ee8b7da8000f thold plugin introduce mismatch hook-register and function name in 6c357c9d (for Cacti 1.3 develop branch)
