### PR TITLE
Fixed: error_reporting() does not support string format MACRO since PHP 8.0

### DIFF
--- a/cli_import.php
+++ b/cli_import.php
@@ -25,7 +25,7 @@
 /* let PHP run just as long as it has to */
 ini_set('max_execution_time', '0');
 
-error_reporting('E_ALL');
+error_reporting(E_ALL);
 
 include(dirname(__FILE__) . '/../../include/cli_check.php');
 include_once($config['base_path'] . '/lib/xml.php');

--- a/cli_thresholds.php
+++ b/cli_thresholds.php
@@ -25,7 +25,7 @@
 /* let PHP run just as long as it has to */
 ini_set('max_execution_time', '0');
 
-error_reporting('E_ALL');
+error_reporting(E_ALL);
 $dir = dirname(__FILE__);
 chdir($dir);
 


### PR DESCRIPTION
```
# php -q cli_import.php -V
PHP Fatal error:  Uncaught TypeError: error_reporting(): Argument #1 ($error_level) must be of type ?int, string given in /var/www/html/cacti/plugins/thold/cli_import.php:28
Stack trace:
#0 /var/www/html/cacti/plugins/thold/cli_import.php(28): error_reporting()
#1 {main}
  thrown in /var/www/html/cacti/plugins/thold/cli_import.php on line 28