### PR TITLE
fix #562 - Thold shows big numbers for bandwidth percentage CDEF (or RPN) #562

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 --- develop ---
 
+* issue#562: Thold shows big numbers for bandwidth percentage CDEF (or RPN)
+
 * feature#497: Show acknowledgment status on Thresholds tab instead of log
 
 * issue#147: Fixed threshold compare negative baseline values.

--- a/thold_functions.php
+++ b/thold_functions.php
@@ -793,7 +793,7 @@ function thold_get_currentval(&$thold_data, &$rrd_reindexed, &$rrd_time_reindexe
 					}
 
 					/* assume counter reset if greater than max value */
-					if ($thold_data['rrd_maximum'] > 0 && $currentval > $thold_data['rrd_maximum']) {
+					if ($thold_data['rrd_maximum'] > 0 && ($currentval / $step) > $thold_data['rrd_maximum']) {
 						$currentval = $item[$thold_data['name']] / $step;
 					} elseif ($thold_data['rrd_maximum'] == 0 && $currentval > 4.25E+9) {
 						$currentval = $item[$thold_data['name']] / $step;


### PR DESCRIPTION
https://github.com/Cacti/plugin_thold/issues/562