### PR TITLE
Hack fix for name/name_cache length for v0.4.4 and v1.2

### DIFF
--- a/includes/database.php
+++ b/includes/database.php
@@ -855,7 +855,7 @@ function thold_upgrade_database($force = false) {
 		// Add additional columns for new features
 		db_add_column('thold_data', array(
 			'name'    => 'name_cache',
-			'type'    => 'varchar(100)',
+			'type'    => 'varchar(150)',
 			'NULL'    => false,
 			'default' => '',
 			'after'   => 'name'));
@@ -1687,8 +1687,8 @@ function thold_setup_database() {
 	$data = array();
 	$data['columns'][] = array('name' => 'id', 'type' => 'int(11)', 'NULL' => false, 'auto_increment' => true);
 	$data['columns'][] = array('name' => 'thread_id', 'type' => 'int(11)', 'unsigned' => true, 'NULL' => false, 'default' => '0');
-	$data['columns'][] = array('name' => 'name', 'type' => 'varchar(100)', 'NULL' => true);
-	$data['columns'][] = array('name' => 'name_cache', 'type' => 'varchar(100)', 'NULL' => true);
+	$data['columns'][] = array('name' => 'name', 'type' => 'varchar(150)', 'NULL' => true);
+	$data['columns'][] = array('name' => 'name_cache', 'type' => 'varchar(150)', 'NULL' => true);
 	$data['columns'][] = array('name' => 'local_data_id', 'type' => 'int(11)', 'NULL' => false, 'default' => '0');
 	$data['columns'][] = array('name' => 'data_template_rrd_id', 'type' => 'int(11)', 'NULL' => false, 'unsigned' => true, 'default' => '0');
 	$data['columns'][] = array('name' => 'local_graph_id', 'type' => 'int(11)', 'NULL' => false, 'default' => '0');


### PR DESCRIPTION
After read database.php code:
* Since v0.4.4, `name` column is extended to 150
* Since v1.2, `name_cache` is added

But:
* `name_cache` column len is initial to 100 since v1.2
* name/name_cache length is still 100 in thold_setup_database function 