### PR TITLE
Prevent zero threshold value CPU loop

### DIFF
--- a/thold_functions.php
+++ b/thold_functions.php
@@ -5164,6 +5164,10 @@ function thold_raw_to_display($number) {
 		return false;
 	}
 
+	if ($number == 0) {
+		return trim($number);
+	}
+	
 	if ($number > 0) {
 		$multiplier = 1;
 	} else {


### PR DESCRIPTION
In trying to edit a specific threshold, the webpage hung and the web server task consumed the CPU.  Eventually a 500 error was returned when the PHP limit was hit.  After adding debug output progressively through the code, it was determined that the loop was triggered by a threshold low value of zero in the function that converts from raw to display format.  With this change, the loop no longer occurs.