### PR TITLE
RPN CDEF error handling

### DIFF
--- a/thold_functions.php
+++ b/thold_functions.php
@@ -4575,10 +4575,12 @@ function thold_rpn($x, $y, $z) {
 
 	if (!is_numeric($x)) {
 		cacti_log("WARNING: Erroneous CDEF logic, the first value should be numeric, but is '$x'", false, 'THOLD');
+		return '';
 	}
 
 	if (!is_numeric($y)) {
 		cacti_log("WARNING: Erroneous CDEF logic, the second value should be numeric, but is '$y'", false, 'THOLD');
+		return '';
 	}
 
 	switch ($z) {


### PR DESCRIPTION
When an RPN expression (|ds:cpu|,*1) item is not an expected, numeric value (*1),  the validation logs a warning "Erroneous CDEF ... should be numeric" but continues to try to use the bad value.  A PHP error occurs and disables the plugin.  I do not know if that is expected and preferred so to get a notification or if the plugin should continue to function and process other items.  This change would exit the function after the validation error, making it a soft error instead, so that the plugin would remain enabled.