### PR TITLE
fix str_replace null value deprecated

### DIFF
--- a/thold_functions.php
+++ b/thold_functions.php
@@ -7558,7 +7558,7 @@ function thold_get_cached_name(&$thold_data) {
 }
 
 function thold_str_replace($search, $replace, $subject) {
-	if (empty($replace) && $replace != 0) {
+	if (empty($replace) || $replace == 0) {
 		$replace = '';
 	}
 


### PR DESCRIPTION
The following error occurred on device down notification due to a host null location.

```
CMDPHP PHP ERROR Backtrace: (
/plugins/thold/poller_thold.php[96]:perform_thold_processes(), 
/plugins/thold/poller_thold.php[140]:thold_update_host_status(), 
/plugins/thold/includes/polling.php[476]:thold_str_replace(), 
/plugins/thold/thold_functions.php[~7572]:str_replace(), CactiErrorHandler())
ERROR PHP DEPRECATED in Plugin 'thold': str_replace(): 
Passing null to parameter #2 ($replace) of type array|string is deprecated in file: 
/var/www/html/cacti/plugins/thold/thold_functions.php on line: ~7572
```
This change assumes the intent is to catch null and zero values.
