### PR TITLE
report function and ref_value fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,10 @@
 
 * issue: Fix potential divide by zero errors with an empty baseu
 
+* issue: Fix undefined function reports_load_format_file
+
+* issue: Fix table columns bi_reference_* values
+
 --- 1.6.0 ---
 
 * feature: Enhance thold daemon to work more efficiently


### PR DESCRIPTION
This fixes error:
`PHP ERROR in Plugin 'thold': Uncaught Error: Call to undefined function reports_load_format_file() in /var/www/html/cacti/plugins/thold/thold_functions.php:~6298`

In troubleshooting the following error, additional detail was added to CDEF/RPN which is hopefully helpful if ever occurs.
`THOLD WARNING: Erroneous CDEF logic, the first value should be numeric, but is '-nan'`

The table columns bi_reference_* values are changed, assuming that is the intent.

In troubleshooting, I struggled with the meaning of the thold_type and data_type literals.  I noticed that Standards-Code-Formatting.md mentions to use constants.  Let me know if it would be acceptable to add and use constants to hold_functions.php.  What names would be helpful?

THOLD_TYPE_HILO
THOLD_TYPE_BASELINE
THOLD_TYPE_TIME

THOLD_DATA_TYPE_EXACT
THOLD_DATA_TYPE_CDEF
THOLD_DATA_TYPE_PERCENT
THOLD_DATA_TYPE_RPN
THOLD_DATA_TYPE_UPLO

Alternately, if acceptable I will add comments.