### PR TITLE
Fix template log and new threshold copy

### DIFF
--- a/thold_functions.php
+++ b/thold_functions.php
@@ -1886,7 +1886,7 @@ function plugin_thold_log_changes($id, $changed, $message = array()) {
 			$desc .= ' Thold Type[' . $thold_types[$message['thold_type']] . ']';
 		}
 
-		$desc .= ' Enabled: ' . ($thold['thold_enabled'] == 'on' && $thold['thold_per_enabled'] == 'on' ? 'on':'off');
+		$desc .= ' Enabled: ' . ($thold['thold_enabled'] == 'on' ? 'on':'off');
 
 		switch ($message['thold_type']) {
 		case 0:
@@ -5887,11 +5887,14 @@ function thold_create_thold_save_from_template($save, $template) {
 	$save['notify_warning_extra'] = $template['notify_warning_extra'];
 
 	// Data Manipulation
-	$save['data_type']  = $template['data_type'];
-	$save['cdef']       = $template['cdef'];
-	$save['percent_ds'] = $template['percent_ds'];
-	$save['expression'] = $template['expression'];
-	$save['upper_ds']   = $template['upper_ds'];
+	$save['data_type']    = $template['data_type'];
+	$save['cdef']         = $template['cdef'];
+	$save['percent_ds']   = $template['percent_ds'];
+	$save['expression']   = $template['expression'];
+	$save['upper_ds']     = $template['upper_ds'];
+	$save['decimals']     = $template['decimals'];
+	$save['units_suffix'] = $template['units_suffix'];
+	$save['show_units']   = $template['show_units'];
 
 	// Hrules
 	$save['thold_hrule_alert']   = $template['thold_hrule_alert'];


### PR DESCRIPTION
This fixes a logged error in function plugin_thold_log_changes() (section modified_template) when editing and saving a template.
`ERROR PHP WARNING in Plugin 'thold': Undefined array key "thold_per_enabled" in file: /var/www/html/cacti/plugins/thold/thold_functions.php on line: ~1889
`

This adds to also copy the values decimals, units_suffix and show_units to the threshold when creating a threshold from a template via a data source list action, assuming that was expected and just missed.