### PR TITLE
Fix #627 save threshold level enabled setting

### DIFF
--- a/thold_functions.php
+++ b/thold_functions.php
@@ -2071,7 +2071,9 @@ function thold_check_threshold(&$thold_data) {
 	thold_modify_values_by_cdef($thold_data);
 
 	thold_debug('Checking Threshold:' .
-		' Name: ' . var_export($thold_data['data_source_name'],true) .
+		' ID: ' . var_export($thold_data['id'],true) .
+		', name: ' . var_export($thold_data['name_cache'],true) .
+		', data source: ' . var_export($thold_data['data_source_name'],true) .
 		', local_data_id: ' . var_export($thold_data['local_data_id'],true) .
 		', data_template_rrd_id: ' . var_export($thold_data['data_template_rrd_id'],true) .
 		', value: ' . var_export($thold_data['lastread'],true));
@@ -5352,7 +5354,8 @@ function save_thold() {
 			array($data_template_rrd_id));
 	}
 
-	$template_enabled = isset_request_var('template_enabled') && get_nfilter_request_var('template_enabled') == 'on' ? 'on' : 'off';
+	$template_enabled  = isset_request_var('template_enabled') && get_nfilter_request_var('template_enabled') == 'on' ? 'on' : 'off';
+	$thold_per_enabled = isset_request_var('thold_per_enabled'   ) && get_nfilter_request_var('thold_per_enabled'   ) == 'on' ? 'on' : '';
 
 	if ($template_enabled == 'on') {
 		if ($local_graph_id > 0 && !is_thold_allowed_graph($local_graph_id)) {
@@ -5364,9 +5367,9 @@ function save_thold() {
 
 		if (get_request_var('id') > 0) {
 			db_execute_prepared('UPDATE thold_data
-				SET template_enabled = "on"
+				SET template_enabled = "on", thold_per_enabled = ?
 				WHERE id = ?',
-				array(get_request_var('id')));
+				array($thold_per_enabled, get_request_var('id')));
 		}
 
 		$data = db_fetch_row_prepared('SELECT id, thold_template_id
@@ -5528,6 +5531,7 @@ function save_thold() {
 	$save['data_template_rrd_id'] = $data_template_rrd_id;
 	$save['local_data_id']        = $local_data_id;
 	$save['thold_enabled']        = isset_request_var('thold_enabled') && get_request_var('thold_enabled') == 'on' ? 'on':'off';
+	$save['thold_per_enabled']    = isset_request_var('thold_per_enabled') && get_request_var('thold_per_enabled') == 'on' ? 'on':'';
 
 	if ($thold_template_id > 0) {
 		$save['thold_template_id'] = $thold_template_id;

--- a/thold_graph.php
+++ b/thold_graph.php
@@ -391,6 +391,9 @@ function tholds() {
 
 	$sql_where = '';
 
+	/* Excluded disabled hosts */
+	$sql_where = '( h.status = 3';
+
 	if (get_request_var('rfilter') != '') {
 		$sql_where .= ($sql_where == '' ? '(': ' AND ') . " td.name_cache RLIKE '" . get_request_var('rfilter') . "'";
 	}


### PR DESCRIPTION
This is related to my issue #627.  On my server on the threshold edit page, the threshold level enabled status (thold_per_enabled) would not save.  I did not find where it was coded to be saved.  I noticed in function save_thold() that for templated thresholds, only the template propagation setting (template_enabled) was saved.  In case it helps, these are my changes that worked for me.

For the Thold edit, this adds to save the threshold level enabled setting thold_per_enabled for templated and non-templated thresholds.  The disabled/off value of "" matches the management actions Disable.  In debugging it, I added additional details in the debug output.

Also while working with it, I noticed on the Thold tab list of thresholds that thresholds for disabled devices were included.  The link to the threshold edit returned a permission denied error.  The device was not in the device filter prompt list.  This changes to exclude disabled devices on the Thold tab list.  If the other is usable and this one is not logical, let me know and I will remove it.