### PR TITLE
Fix hi/lo validation

### DIFF
--- a/thold_functions.php
+++ b/thold_functions.php
@@ -5429,7 +5429,7 @@ function save_thold() {
 		if (get_request_var('thold_type') == 0 &&
 			get_request_var('thold_hi') != '' &&
 			get_request_var('thold_low') != '' &&
-			round(get_request_var('thold_low'),4) >= round(get_request_var('thold_hi'), 4)) {
+			trim_round_request_var('thold_low', 4, 'thold_low') >= trim_round_request_var('thold_hi', 4, 'thold_hi')) {
 
 			$banner = __('Impossible thresholds: \'High Threshold\' smaller than or equal to \'Low Threshold\'<br>RECORD NOT UPDATED!', 'thold');
 
@@ -5441,7 +5441,7 @@ function save_thold() {
 		if (get_request_var('thold_type') == 0 &&
 			get_request_var('thold_warning_hi') != '' &&
 			get_request_var('thold_warning_low') != '' &&
-			round(get_request_var('thold_warning_low'),4) >= round(get_request_var('thold_warning_hi'), 4)) {
+			trim_round_request_var('thold_warning_low', 4, 'thold_warning_low') >= trim_round_request_var('thold_warning_hi', 4, 'thold_warning_hi')) {
 
 			$banner = __('Impossible thresholds: \'High Warning Threshold\' smaller than or equal to \'Low Warning Threshold\'<br>RECORD NOT UPDATED!', 'thold');
 


### PR DESCRIPTION
Hi and lo values with units (7G, 1G) cause an error.  This fixes the validation.

ERROR PHP ERROR in Plugin 'thold': Uncaught TypeError: round(): Argument #1 ($num) must be of type int|float, string given in /var/www/html/cacti/plugins/thold/thold_functions.php:5432 Stack trace: #0 /var/www/html/cacti/plugins/thold/thold_functions.php(5432): round() #1 /var/www/html/cacti/plugins/thold/thold.php(96): save_thold() #2 {main} thrown in file: /var/www/html/cacti/plugins/thold/thold_functions.php on line: 5432