### PR TITLE
fix uncorrect condition

### DIFF
--- a/thold_functions.php
+++ b/thold_functions.php
@@ -7748,7 +7748,7 @@ function thold_get_cached_name(&$thold_data) {
 }
 
 function thold_str_replace($search, $replace, $subject) {
-	if (empty($replace) || $replace == 0) {
+	if (empty($replace) || $replace === 0) {
 		$replace = '';
 	}
 


### PR DESCRIPTION
 For "fdfsdfs" == 0 condition is different result in php 8 and older versions
https://www.php.net/manual/en/types.comparisons.php
Fix #634 