### PR TITLE
Update settings.php missing 'description' key for 'thold_notification_delay' field

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -718,6 +718,7 @@ function thold_config_settings() {
 		),
 		'thold_notification_delay' => array(
 			'friendly_name' => __('Device Notification Delay Options', 'thold'),
+			'description' => __('Device Notification Delay Options', 'thold'),
 			'method' => 'hidden',
 			//'method' => 'spacer',
 		),


### PR DESCRIPTION
CACTI [1.3.0 DEV]

Update settings.php missing 'description' key for 'thold_notification_delay' field

'description' => __('Device Notification Delay Options', 'thold'),