### PR TITLE
thold_notification_delay does not have description key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 --- develop ---
 
+* issue#682: Setting.php thold_notification_delay field does not have 'description' key
 * issue#673: Device up/down notification emails don't appear to be sent if the notification queue is enabled
 * issue#674: Thold Current Value is incorrect in 1.8.1
 * issue#678: Unable to remove suspended notifications one by one

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -718,6 +718,7 @@ function thold_config_settings() {
 		),
 		'thold_notification_delay' => array(
 			'friendly_name' => __('Device Notification Delay Options', 'thold'),
+			'description' => __('Device Notification Delay Options', 'thold'),
 			'method' => 'hidden',
 			//'method' => 'spacer',
 		),


### PR DESCRIPTION
Cacti 1.3.0 DEV

thold plugin
settings.php
thold_notification_delay does not have description key

Solution:
add description key

		'thold_notification_delay' => array(
			'friendly_name' => __('Device Notification Delay Options', 'thold'),
			'description' => __('Device Notification Delay Options', 'thold'),
 			'method' => 'hidden',
			//'method' => 'spacer',
		),