### PR TITLE
Fix #684 - unable to create baseline deviation threshold templates

### DIFF
--- a/thold_functions.php
+++ b/thold_functions.php
@@ -5875,7 +5875,6 @@ function thold_validate_save($save, $type = 'thold_template') {
 		 * The initial template creation is always hi/low.  So, we
 		 * do not require an isset in this section.
 		 */
-		$banner .= ($banner != '' ? '<br>':'') . __('With baseline thresholds enabled.', 'thold');
 
 		if (empty($save['bl_ref_time_range']) || $save['bl_ref_time_range'] <= 0) {
 			$banner .= ($banner != '' ? '<br>':'') . __('Time reference in the past must be set to positive integer value!', 'thold');


### PR DESCRIPTION
$banner is being populated regardless of whether an error is detected or not. The subsequent code on lines 5965-5969 raises an error if $banner is not empty.

Removed line 5878 to fix the issue.