### PR TITLE
PHP error - $failed is not always array

### DIFF
--- a/includes/polling.php
+++ b/includes/polling.php
@@ -848,7 +848,7 @@ function thold_update_host_status() {
 
 		foreach ($hosts as $host) {
 			//hosts in recovery status record only if they was in failed status
-			if (($host['status'] != HOST_RECOVERING) OR ($host['status'] == HOST_RECOVERING AND (array_search($host['id'], array_column($failed, 'host_id')) !== false))) {
+			if (($host['status'] != HOST_RECOVERING) OR ($host['status'] == HOST_RECOVERING AND (is_array($failed) && array_search($host['id'], array_column($failed, 'host_id')) !== false))) {
 
 				$failed_ids .= ($failed_ids != '' ? '), (':'(') . $host['id'];
 			}


### PR DESCRIPTION
I did restart of more devices and thold crash with:
Cacti disabled plugin thold due to the following error: PHP ERROR in Plugin 'thold': Uncaught TypeError: array_column(): Argument #1 ($array) must be of type array, false given in /usr/local/share/cacti/plugins/thold/includes/polling.php:851 Stack trace: #0 /usr/local/share/cacti/plugins/thold/includes/polling.php(851): array_column(false, 'host_id') #1 /usr/local/share/cacti/plugins/thold/poller_thold.php(158): thold_update_host_status() #2 /usr/local/share/cacti/plugins/thold/poller_thold.php(99): perform_thold_processes() #3 {main} thrown in file: /usr/local/share/cacti/plugins/thold/includes/polling.php on line: 851! See the Cacti logfile for more details.