### PR TITLE
causes Unsupported operand types: int + string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * issue#674: Thold Current Value is incorrect in 1.8.1
 * issue#678: Unable to remove suspended notifications one by one
 * issue#679: The PHP Mailer does not allow for the to and bcc addresses to be the same
+* issue#700: PHP8.x issue - addition a non-numeric value
 * feature#677: Allow the Administrator to create a default Single Email Notification Subject
 * feature#696: Extend email replacement (location, site, ...) for subject and email body
 

--- a/thold_functions.php
+++ b/thold_functions.php
@@ -4764,7 +4764,7 @@ function get_current_value($local_data_id, $data_template_rrd_id, $cdef = 0) {
 
 	// Return Blank if the data source is not found (Newly created?)
 	if (!isset($result['data_source_names'])) {
-		return '';
+		return 0;
 	}
 
 	$idx = array_search($data_template_rrd_id, $result['data_source_names']);
@@ -4772,7 +4772,7 @@ function get_current_value($local_data_id, $data_template_rrd_id, $cdef = 0) {
 	// Return Blank if the value was not found (Cache Cleared?)
 
 	if (!isset($result['values']) || $idx === null || !cacti_sizeof($result['values'][$idx])) {
-		return '';
+		return 0;
 	}
 
 	$value = array_values($result['values'][$idx])[0];


### PR DESCRIPTION
fix #699 

second posibility is change 
total += get_current_value($local_data_id, $dsn['data_source_name']);
to
total += (int) get_current_value($local_data_id, $dsn['data_source_name']);

from a quick check of the code, this looks better to me. What do you think @TheWitness   ?