### PR TITLE
Ensure show_units column is added

### DIFF
--- a/includes/database.php
+++ b/includes/database.php
@@ -1307,7 +1307,7 @@ function thold_upgrade_database($force = false) {
 			'after'    => 'notify_warning_extra'));
 	}
 
-	if (cacti_version_compare($oldv, '1.5', '<')) {
+	if (cacti_version_compare($oldv, '1.5.1', '<')) {
 		api_plugin_db_add_column('thold', 'host', array(
 			'name'     => 'thold_failure_count',
 			'type'     => 'int(10)',


### PR DESCRIPTION
In version 1.5 of thold there was a Bug where some columns were missed during install  the upgrade script looked for a thold version of less than 1.5 to add the columns