### PR TITLE
remove white chars from email address list

### DIFF
--- a/notify_lists.php
+++ b/notify_lists.php
@@ -81,8 +81,8 @@ function form_save() {
 		$save['name']        = form_input_validate(get_nfilter_request_var('name'), 'name', '', false, 3);
 		$save['enabled']     = isset_request_var('enabled') ? 'on':'';
 		$save['description'] = form_input_validate(get_nfilter_request_var('description'), 'description', '', false, 3);
-		$save['emails']      = form_input_validate(get_nfilter_request_var('emails'), 'emails', '', true, 3);
-		$save['bcc_emails']  = form_input_validate(get_nfilter_request_var('bcc_emails'), 'bcc_emails', '', true, 3);
+		$save['emails']      = preg_replace('/\s+/', '', form_input_validate(get_nfilter_request_var('emails'), 'emails', '', true, 3));
+		$save['bcc_emails']  = preg_replace('/\s+/', '', form_input_validate(get_nfilter_request_var('bcc_emails'), 'bcc_emails', '', true, 3));
 		$save['format_file'] = form_input_validate(get_nfilter_request_var('format_file'), 'format_file', '', true, 3);
 
 		$bccs   = explode(',', $save['bcc_emails']);

--- a/thold_functions.php
+++ b/thold_functions.php
@@ -5577,10 +5577,10 @@ function save_thold() {
 	if ($thold_template_id == 0) {
 		$save['thold_enabled'] = 'on';
 	} else {
-		$save['thold_enabled'] = isset_request_var('thold_enabled') && get_request_var('thold_enabled') == 'on' ? 'on':'off';
+		$save['thold_enabled'] = isset_request_var('thold_enabled') && get_nfilter_request_var('thold_enabled') == 'on' ? 'on':'off';
 	}
 
-	$save['thold_per_enabled'] = isset_request_var('thold_per_enabled') && get_request_var('thold_per_enabled') == 'on' ? 'on':'';
+	$save['thold_per_enabled'] = isset_request_var('thold_per_enabled') && get_nfilter_request_var('thold_per_enabled') == 'on' ? 'on':'';
 
 	if ($thold_template_id > 0) {
 		$save['thold_template_id'] = $thold_template_id;
@@ -7782,15 +7782,15 @@ function get_thold_notification_emails($id = '', $recipient = 'to') {
 
 	if (!empty($id)) {
 		if ($recipient == 'to') {
-			return trim(db_fetch_cell_prepared('SELECT emails
+			return preg_replace('/\s+/', '', trim(db_fetch_cell_prepared('SELECT emails
 				FROM plugin_notification_lists
 				WHERE id = ?',
-				array($id)));
+				array($id))));
 		} else {
-			return trim(db_fetch_cell_prepared('SELECT bcc_emails
+			return preg_replace('/\s+/', '', trim(db_fetch_cell_prepared('SELECT bcc_emails
 				FROM plugin_notification_lists
 				WHERE id = ?',
-				array($id)));
+				array($id))));
 		}
 	} else {
 		return '';


### PR DESCRIPTION
space (or other white chars) in "to" or "bcc" will cause email to be delivered only to users before first white space. Maybe it is problem only with specific email servers.

Second fix is for:
2025-10-03 09:37:13 - CMDPHP Input Validation Not Performed for 'thold_per_enabled' Backtrace:  (/plugins/thold/thold.php[96]:save_thold(), /plugins/thold/thold_functions.php[5583]:get_reque
st_var(), /lib/html_utility.php[379]:html_log_input_error(), /lib/html_validate.php[44]:cacti_debug_backtrace())
