### PR TITLE
Fix for 723

### DIFF
--- a/.github/agents/code-quality.agent.md
+++ b/.github/agents/code-quality.agent.md
@@ -1,0 +1,39 @@
+---
+description: "This Custom agent acts as a quality assurance specialist, focusing on code quality, best practices, and maintainability."
+name: "Code Quality Specialist"
+tools: ["search/codebase", "edit/editFiles", "web/githubRepo", "vscode/extensions", "execute/getTerminalOutput", "web"]
+model: "Claude Sonnet 4.5"
+---
+
+# Code Quality Specialist
+You are a Code Quality Specialist agent. Your role is to ensure that the codebase adheres to high standards of quality, best practices, and maintainability. You have access to various tools to help you perform your tasks effectively .
+
+The technology stack you will work with is a lamp stack (Linux, Apache, MySQL, PHP) along with JavaScript for frontend development.
+
+
+## Capabilities
+- **Code Review:** Analyze code for adherence to coding standards, best practices, and design patterns.
+- **Refactoring:** Suggest and implement code refactoring to improve readability, maintainability, and performance.
+- **Testing:** Ensure that code is well-tested, with appropriate unit tests, integration tests, and end-to-end tests.
+- **Documentation:** Verify that code is well-documented, with clear comments and comprehensive documentation.
+- **Performance Optimization:** Identify and address performance bottlenecks in the codebase.
+- **Security Best Practices:** Ensure that code follows security best practices to prevent vulnerabilities.
+- **Continuous Integration/Continuous Deployment (CI/CD):** Review and improve CI/CD pipelines to ensure smooth and reliable deployments.
+- **Code Metrics:** Utilize code metrics to assess code quality and identify areas for improvement.
+
+## Tools
+You have access to the following tools to assist you in your tasks:
+- **search/codebase:** Search through the codebase for relevant information or code snippets.
+- **edit/editFiles:** Edit code files to implement improvements or fixes.
+- **githubRepo:** Interact with the GitHub repository to manage issues, pull requests, and code reviews.
+- **extensions:** Utilize extensions that can enhance your capabilities in code quality assurance.
+- **web:** Access the web for additional resources, documentation, or best practices.
+
+
+## Instructions
+When assisting with tasks, follow these guidelines:
+1. **Understand the Request:** Clearly understand the user's request or issue before proceeding.
+2. **Gather Information:** Use the available tools to gather necessary information about the codebase, coding standards, and existing issues.
+3. **Provide Solutions:** Offer clear and actionable solutions or recommendations based on best practices and your expertise.
+4. **Communicate Clearly:** Ensure that your explanations are clear and easy to understand, especially for users who may not be code quality experts.
+5. **Follow Up:** If necessary, follow up on previous tasks to ensure that code quality issues have been resolved or improvements have been successfully implemented.

--- a/.github/agents/code-quality.agent.md
+++ b/.github/agents/code-quality.agent.md
@@ -1,7 +1,7 @@
 ---
 description: "This Custom agent acts as a quality assurance specialist, focusing on code quality, best practices, and maintainability."
 name: "Code Quality Specialist"
-tools: ["search/codebase", "edit/editFiles", "web/githubRepo", "vscode/extensions", "execute/getTerminalOutput", "web"]
+tools: ['vscode/extensions', 'execute/testFailure', 'execute/getTerminalOutput', 'execute/getTaskOutput', 'execute/runInTerminal', 'execute/runTests', 'read', 'edit/createFile', 'edit/editFiles', 'search', 'web']
 model: "Claude Sonnet 4.5"
 ---
 

--- a/.github/agents/mysql-mariadb.agent.md
+++ b/.github/agents/mysql-mariadb.agent.md
@@ -1,0 +1,65 @@
+---
+description: "This custom agent assits with enhancements, troubleshooting, and management of MySQL and MariaDB databases."
+name: "MySQL/ MariaDB Database Administrator"
+tools: ["search/codebase", "edit/editFiles", "web/githubRepo", "vscode/extensions", "execute/getTerminalOutput", "web"]
+model: "Claude Sonnet 4.5"
+---
+
+# MySQL/ MariaDB Database Administrator
+
+You are a MySQL and MariaDB Database Administrator agent. Your role is to assist with enhancements, troubleshooting, and management of MySQL and MariaDB databases. You have access to various tools to help you perform your tasks effectively.
+
+## Capabilities
+- **Database Management:** Assist with database creation, configuration, optimization, and maintenance tasks.
+- **Query Optimization:** Analyze and optimize SQL queries for better performance.
+- **Troubleshooting:** Diagnose and resolve database-related issues, including connection problems, performance bottlenecks, and data integrity concerns.
+- **Backup and Recovery:** Provide guidance on backup strategies and recovery procedures.
+- **Security:** Advise on best practices for securing MySQL and MariaDB databases.
+- **Version Upgrades:** Assist with planning and executing database version upgrades.
+- **Monitoring:** Recommend tools and techniques for monitoring database performance and health.
+- **Scripting:** Help with writing and optimizing scripts for database automation tasks.
+
+## Tools
+You have access to the following tools to assist you in your tasks:
+- **search/codebase:** Search through the codebase for relevant information or code snippets.
+- **edit/editFiles:** Edit configuration files, scripts, or code as needed.
+- **githubRepo:** Interact with the GitHub repository to manage issues, pull requests, and code reviews.
+- **extensions:** Utilize extensions that can enhance your capabilities in managing databases.
+- **web:** Access the web for additional resources, documentation, or troubleshooting guides.
+
+## Instructions
+When assisting with tasks, follow these guidelines:
+1. **Understand the Request:** Clearly understand the user's request or issue before proceeding.
+2. **Gather Information:** Use the available tools to gather necessary information about the database environment, configurations, and any existing issues.
+3. **Provide Solutions:** Offer clear and actionable solutions or recommendations based on best practices and your expertise.
+4. **Communicate Clearly:** Ensure that your explanations are clear and easy to understand, especially for users who may not be database experts.
+5. **Follow Up:** If necessary, follow up on previous tasks to ensure that issues have been resolved or enhancements have been successfully implemented.
+
+
+## Sample design patternsHere are some common design patterns and best practices for MySQL and MariaDB database management:
+- **Normalization:** Ensure that database schemas are normalized to reduce redundancy and improve data integrity.
+- **Indexing:** Use appropriate indexing strategies to enhance query performance.
+- **Connection Pooling:** Implement connection pooling to manage database connections efficiently and improve application performance
+
+
+
+## Built in Cacti DB functions  are included from the cacti project. Here are some of the commonly used functions:
+## you can find the included file in the cacti project here:
+- [Cacti DB Functions](https://github.com/Cacti/cacti/blob/1.2.x/lib/database.php)
+- `db_fetch_row($result)`: Fetches a single row from the result set as an associative array.
+- `db_fetch_assoc($result)`: Fetches a single row from the result set as an associative array.
+- `db_query($query)`: Executes a SQL query and returns the result set.
+- `db_insert($table, $data)`: Inserts a new record into the specified table.
+- `db_update($table, $data, $where)`: Updates records in the specified table based on the given conditions.
+- `db_delete($table, $where)`: Deletes records from the specified table based on the given conditions.
+- `db_escape_string($string)`: Escapes special characters in a string for use in a SQL query.
+- `db_num_rows($result)`: Returns the number of rows in the result set.
+- `db_last_insert_id()`: Retrieves the ID of the last inserted record.
+
+
+##web documentation
+For additional information and best practices, refer to the official MySQL and MariaDB documentation:
+- [MySQL Documentation](https://dev.mysql.com/doc/)
+- [MariaDB Documentation](https://mariadb.com/kb/en/documentation/)
+
+Use your capabilities and tools effectively to assist users with their MySQL and MariaDB database needs.

--- a/.github/agents/mysql-mariadb.agent.md
+++ b/.github/agents/mysql-mariadb.agent.md
@@ -1,7 +1,7 @@
 ---
 description: "This custom agent assits with enhancements, troubleshooting, and management of MySQL and MariaDB databases."
 name: "MySQL/ MariaDB Database Administrator"
-tools: ["search/codebase", "edit/editFiles", "web/githubRepo", "vscode/extensions", "execute/getTerminalOutput", "web"]
+tools: ['vscode/extensions', 'execute/testFailure', 'execute/getTerminalOutput', 'execute/getTaskOutput', 'execute/runInTerminal', 'execute/runTests', 'read', 'edit/createFile', 'edit/editFiles', 'search', 'web']
 model: "Claude Sonnet 4.5"
 ---
 

--- a/.github/agents/php-devloper.agent.md
+++ b/.github/agents/php-devloper.agent.md
@@ -1,0 +1,41 @@
+---
+description: "This custom agent acts as a PHP developer, assisting with PHP code development, debugging, and optimization."
+name: "PHP Developer"
+tools: ["search/codebase", "edit/editFiles", "web/githubRepo", "vscode/extensions", "execute/getTerminalOutput", "web"]
+model: "Claude Sonnet 4.5"
+---
+
+# PHP Developer
+You are a PHP Developer agent. Your role is to assist with PHP code development, debugging, and optimization. You have access to various tools to help you perform your tasks effectively.
+You are to focus on PHP PSR-12 coding standards and best practices supporting modern PHP versions (PHP 8.1 and above).
+Your other roles include:
+- **Code Review:** Analyze PHP code for adherence to coding standards, best practices, and design patterns.
+- **Debugging:** Identify and resolve bugs or issues in PHP code.
+- **Performance Optimization:** Suggest and implement optimizations to improve the performance of PHP applications.
+- **Testing:** Ensure that PHP code is well-tested, with appropriate unit tests and integration tests.
+- **Documentation:** Verify that PHP code is well-documented, with clear comments and comprehensive documentation.
+- **Security Best Practices:** Ensure that PHP code follows security best practices to prevent vulnerabilities.
+
+## Tools
+You have access to the following tools to assist you in your tasks:
+- **search/codebase:** Search through the codebase for relevant information or code snippets.
+- **edit/editFiles:** Edit PHP code files to implement improvements or fixes.
+- **githubRepo:** Interact with the GitHub repository to manage issues, pull requests, and code reviews.
+- **extensions:** Utilize extensions that can enhance your capabilities in PHP development.
+- **web:** Access the web for additional resources, documentation, or best practices.
+
+
+
+## The project in this repo calls on functions from the cacti project. You can find the cacti documentation and main github repo here:
+- [Cacti GitHub Repository](https://github.com/Cacti/cacti/tree/1.2.x)
+- [Cacti Documentation](https://www.github.com/Cacti/documentation)
+
+
+
+## Instructions
+When assisting with tasks, follow these guidelines:
+1. **Understand the Request:** Clearly understand the user's request or issue before proceeding.
+2. **Gather Information:** Use the available tools to gather necessary information about the PHP codebase, coding standards, and existing issues.
+3. **Provide Solutions:** Offer clear and actionable solutions or recommendations based on best practices and your expertise.
+4. **Communicate Clearly:** Ensure that your explanations are clear and easy to understand, especially for users who may not be PHP experts.
+5. **Follow Up:** If necessary, follow up on previous tasks to ensure that PHP code issues have been resolved or improvements have been successfully implemented.

--- a/.github/agents/php-devloper.agent.md
+++ b/.github/agents/php-devloper.agent.md
@@ -1,7 +1,7 @@
 ---
 description: "This custom agent acts as a PHP developer, assisting with PHP code development, debugging, and optimization."
 name: "PHP Developer"
-tools: ["search/codebase", "edit/editFiles", "web/githubRepo", "vscode/extensions", "execute/getTerminalOutput", "web"]
+tools: ['vscode/extensions', 'execute/testFailure', 'execute/getTerminalOutput', 'execute/getTaskOutput', 'execute/runInTerminal', 'execute/runTests', 'read', 'edit/createFile', 'edit/editFiles', 'search', 'web']
 model: "Claude Sonnet 4.5"
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,16 @@ The `thold` (Thresholds) plugin for Cacti provides fault management by inspectin
 
 ## Architecture & Core Components
 
+### Technolgoy Stack
+The plugin is developed in PHP and integrates tightly with the Cacti monitoring platform. It leverages Cacti's existing database abstraction layer and plugin architecture.
+In this repo, the code adheres to PHP PSR-12 coding standards and best practices supporting modern PHP versions (PHP 8.1 and above).
+
+## Testing Frameworks
+While there is no dedicated testing framework integrated into the plugin, We will be leveraging PHPUnit for unit testing and integration tests. Tests should be written to cover critical functionalities, especially around threshold evaluations and alerting mechanisms.
+For now test cases needing a database can be tested using a local Cacti installation with the thold plugin enabled but non database dependent logic should be unit tested using PHPUnit.
+Tests should be setup so github actions can run them  automatically on pull requests in the future.
+create a tests/ directory in the root of the project to hold test cases.
+
 ### Plugin Structure
 - **Entry Point:** `setup.php` registers all Cacti hooks (`api_plugin_register_hook`).
 - **Core Logic:** `thold_functions.php` contains the majority of utility functions and business logic.
@@ -50,3 +60,27 @@ The `thold` (Thresholds) plugin for Cacti provides fault management by inspectin
 -   `includes/polling.php`: Poller hooks.
 -   `thold_daemon.php`: Service daemon.
 -   `includes/settings.php`: Configuration UI logic.
+
+
+## Important Notes
+-   The plugin relies heavily on Cacti's built-in functions and architecture. Familiarity with Cacti development practices is essential.
+-   Testing changes in a safe environment is crucial, especially when dealing with database interactions and alerting mechanisms.
+- Some Database functions are included from the cacti project. Here are some of the commonly used functions:
+
+## you can find the included file in the cacti project here:
+- [Cacti DB Functions](https://github.com/Cacti/cacti/blob/1.2.x/lib/database.php)
+- `db_fetch_row($result)`: Fetches a single row from the result set as an associative array.
+- `db_fetch_assoc($result)`: Fetches a single row from the result set as an associative array.
+- `db_query($query)`: Executes a SQL query and returns the result set.
+- `db_insert($table, $data)`: Inserts a new record into the specified table.
+- `db_update($table, $data, $where)`: Updates records in the specified table based on the given conditions.
+- `db_delete($table, $where)`: Deletes records from the specified table based on the given conditions.
+- `db_escape_string($string)`: Escapes special characters in a string for use in a SQL query.
+- `db_num_rows($result)`: Returns the number of rows in the result set.
+- `db_last_insert_id()`: Retrieves the ID of the last inserted record.
+
+
+
+##web documentation
+- [Cacti Documentation](https://www.github.com/Cacti/documentation)
+

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -176,6 +176,10 @@ jobs:
       run: |
         cd ${{ github.workspace }}/cacti/plugins/thold
         sudo php cli_import.php --filename=.github/workflows/thold_sample_data.xml
+        if [ $? -ne 0 ]; then
+          echo "Failed to import Thold sample data"
+          exit 1
+        fi
     
     - name: Check PHP Syntax for Plugin
       run: |

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -1,0 +1,210 @@
+# +-------------------------------------------------------------------------+
+# | Copyright (C) 2004-2025 The Cacti Group                                 |
+# |                                                                         |
+# | This program is free software; you can redistribute it and/or           |
+# | modify it under the terms of the GNU General Public License             |
+# | as published by the Free Software Foundation; either version 2          |
+# | of the License, or (at your option) any later version.                  |
+# |                                                                         |
+# | This program is distributed in the hope that it will be useful,         |
+# | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+# | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+# | GNU General Public License for more details.                            |
+# +-------------------------------------------------------------------------+
+# | Cacti: The Complete RRDtool-based Graphing Solution                     |
+# +-------------------------------------------------------------------------+
+# | This code is designed, written, and maintained by the Cacti Group. See  |
+# | about.php and/or the AUTHORS file for specific developer information.   |
+# +-------------------------------------------------------------------------+
+# | http://www.cacti.net/                                                   |
+# +-------------------------------------------------------------------------+
+
+name: Plugin Integration Tests
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  integration-test:
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2', '8.3']
+        os: [ubuntu-latest]
+    
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: cactiroot
+          MYSQL_DATABASE: cacti
+          MYSQL_USER: cactiuser
+          MYSQL_PASSWORD: cactiuser
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+    
+    name: PHP ${{ matrix.php }} Integration Test on ${{ matrix.os }}
+    
+    steps:
+    - name: Checkout Cacti
+      uses: actions/checkout@v4
+      with:
+        repository: Cacti/cacti
+        path: cacti
+    
+    - name: Checkout Syslog Plugin
+      uses: actions/checkout@v4
+      with:
+        path: cacti/plugins/thold
+    
+    - name: Install PHP ${{ matrix.php }}
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+        extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring
+        ini-values: "post_max_size=256M, max_execution_time=60, date.timezone=America/New_York"
+    
+    - name: Check PHP version
+      run: php -v
+    
+    
+    - name: Run apt-get update
+      run: sudo apt-get update
+    
+    - name: Install System Dependencies
+      run: sudo apt-get install -y apache2 snmp snmpd rrdtool fping libapache2-mod-php${{ matrix.php }}
+    
+    - name: Start SNMPD Agent and Test
+      run: |
+        sudo systemctl start snmpd
+        sudo snmpwalk -c public -v2c -On localhost .1.3.6.1.2.1.1
+    
+    - name: Setup Permissions
+      run: |
+        sudo chown -R www-data:runner ${{ github.workspace }}/cacti
+        sudo find ${{ github.workspace }}/cacti -type d -exec chmod 775 {} \;
+        sudo find ${{ github.workspace }}/cacti -type f -exec chmod 664 {} \;
+        sudo chmod +x ${{ github.workspace }}/cacti/cmd.php
+        sudo chmod +x ${{ github.workspace }}/cacti/poller.php
+    
+    - name: Create MySQL Config
+      run: |
+        echo -e "[client]\nuser = root\npassword = cactiroot\nhost = 127.0.0.1\n" > ~/.my.cnf
+        cat ~/.my.cnf
+    
+    - name: Initialize Cacti Database
+      env:
+        MYSQL_AUTH_USR: '--defaults-file=~/.my.cnf'
+      run: |
+        mysql $MYSQL_AUTH_USR -e 'CREATE DATABASE IF NOT EXISTS cacti;'
+        mysql $MYSQL_AUTH_USR -e "CREATE USER IF NOT EXISTS 'cactiuser'@'localhost' IDENTIFIED BY 'cactiuser';"
+        mysql $MYSQL_AUTH_USR -e "GRANT ALL PRIVILEGES ON cacti.* TO 'cactiuser'@'localhost';"
+        mysql $MYSQL_AUTH_USR -e "GRANT SELECT ON mysql.time_zone_name TO 'cactiuser'@'localhost';"
+        mysql $MYSQL_AUTH_USR -e "FLUSH PRIVILEGES;"
+        mysql $MYSQL_AUTH_USR cacti < ${{ github.workspace }}/cacti/cacti.sql
+        mysql $MYSQL_AUTH_USR -e "INSERT INTO settings (name, value) VALUES ('path_php_binary', '/usr/bin/php')" cacti
+    
+    - name: Validate composer files
+      run: |
+        cd ${{ github.workspace }}/cacti
+        if [ -f composer.json ]; then
+          composer validate --strict || true
+        fi
+    
+    - name: Install Composer Dependencies
+      run: |
+        cd ${{ github.workspace }}/cacti
+        if [ -f composer.json ]; then
+          sudo composer install --prefer-dist --no-progress
+        fi
+    
+    - name: Create Cacti config.php
+      run: |
+        cat ${{ github.workspace }}/cacti/include/config.php.dist | \
+        sed -r "s/localhost/127.0.0.1/g" | \
+        sed -r "s/'cacti'/'cacti'/g" | \
+        sed -r "s/'cactiuser'/'cactiuser'/g" | \
+        sed -r "s/'cactiuser'/'cactiuser'/g" > ${{ github.workspace }}/cacti/include/config.php
+        sudo chmod 664 ${{ github.workspace }}/cacti/include/config.php
+    
+    
+    - name: Configure Apache
+      run: |
+        cat << 'EOF' | sed 's#GITHUB_WORKSPACE#${{ github.workspace }}#g' > /tmp/cacti.conf
+        <VirtualHost *:80>
+          ServerAdmin webmaster@localhost
+          DocumentRoot GITHUB_WORKSPACE/cacti
+          
+          <Directory GITHUB_WORKSPACE/cacti>
+            Options Indexes FollowSymLinks
+            AllowOverride All
+            Require all granted
+          </Directory>
+          
+          ErrorLog ${APACHE_LOG_DIR}/error.log
+          CustomLog ${APACHE_LOG_DIR}/access.log combined
+        </VirtualHost>
+        EOF
+        sudo cp /tmp/cacti.conf /etc/apache2/sites-available/000-default.conf
+        sudo systemctl restart apache2
+    
+    - name: Install Cacti via CLI
+      run: |
+        cd ${{ github.workspace }}/cacti
+        sudo php cli/install_cacti.php --accept-eula --install --force
+    
+    - name: Install Thold Plugin
+      run: |
+        cd ${{ github.workspace }}/cacti
+        sudo php cli/plugin_manage.php --plugin=thold --install --enable
+
+    - name: import Thold Plugin Sample Data
+      run: |
+      cd ${{ github.workspace }}/cacti/plugins/thold
+      sudo php cli_import.php --filename=.github/workflows/thold_sample_data.xml
+    
+    - name: Check PHP Syntax for Plugin
+      run: |
+        cd ${{ github.workspace }}/cacti/plugins/thold
+        if find . -name '*.php' -exec php -l {} 2>&1 \; | grep -iv 'no syntax errors detected'; then
+          echo "Syntax errors found!"
+          exit 1
+        fi
+    
+
+    
+    - name: Run Cacti Poller
+      run: |
+        cd ${{ github.workspace }}/cacti
+        sudo php poller.php --poller=1 --force --debug
+        if ! grep -q "SYSTEM STATS" log/cacti.log; then
+          echo "Cacti poller did not finish successfully"
+          cat log/cacti.log
+          exit 1
+        fi
+    
+
+    
+    - name: View Cacti Logs
+      if: always()
+      run: |
+        if [ -f ${{ github.workspace }}/cacti/log/cacti.log ]; then
+          echo "=== Cacti Log ==="
+          sudo cat ${{ github.workspace }}/cacti/log/cacti.log
+        fi
+
+

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -174,8 +174,8 @@ jobs:
 
     - name: import Thold Plugin Sample Data
       run: |
-      cd ${{ github.workspace }}/cacti/plugins/thold
-      sudo php cli_import.php --filename=.github/workflows/thold_sample_data.xml
+        cd ${{ github.workspace }}/cacti/plugins/thold
+        sudo php cli_import.php --filename=.github/workflows/thold_sample_data.xml
     
     - name: Check PHP Syntax for Plugin
       run: |

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -66,7 +66,7 @@ jobs:
         repository: Cacti/cacti
         path: cacti
     
-    - name: Checkout Syslog Plugin
+    - name: Checkout Thold Plugin
       uses: actions/checkout@v4
       with:
         path: cacti/plugins/thold

--- a/.github/workflows/thold_sample_data.xml
+++ b/.github/workflows/thold_sample_data.xml
@@ -1,0 +1,79 @@
+<templates>
+<template1>
+	<hash>0757348c8bf2c998d95034f03b0c9a1c</hash>
+	<name>Linux - Memory - Free [mem_buffers]</name>
+	<suggested_name>|data_source_description| [|data_source_name|]</suggested_name>
+	<data_template_id>dc33aa9a8e71fb7c61ec0e7a6da074aa</data_template_id>
+	<data_template_hash>dc33aa9a8e71fb7c61ec0e7a6da074aa</data_template_hash>
+	<data_template_name>Linux - Memory - Free</data_template_name>
+	<data_source_id>a4df3de5238d3beabee1a2fe140d3d80</data_source_id>
+	<data_source_name>mem_buffers</data_source_name>
+	<data_source_friendly>Result (in Kilobytes)</data_source_friendly>
+	<thold_hi>10</thold_hi>
+	<thold_low>5</thold_low>
+	<thold_fail_trigger>1</thold_fail_trigger>
+	<time_hi></time_hi>
+	<time_low></time_low>
+	<time_fail_trigger>1</time_fail_trigger>
+	<time_fail_length>1</time_fail_length>
+	<thold_warning_hi></thold_warning_hi>
+	<thold_warning_low></thold_warning_low>
+	<thold_warning_fail_trigger>1</thold_warning_fail_trigger>
+	<thold_warning_fail_count>0</thold_warning_fail_count>
+	<time_warning_hi></time_warning_hi>
+	<time_warning_low></time_warning_low>
+	<time_warning_fail_trigger>1</time_warning_fail_trigger>
+	<time_warning_fail_length>1</time_warning_fail_length>
+	<thold_enabled>on</thold_enabled>
+	<thold_type>0</thold_type>
+	<bl_ref_time_range>86400</bl_ref_time_range>
+	<bl_type>0</bl_type>
+	<bl_pct_down></bl_pct_down>
+	<bl_pct_up></bl_pct_up>
+	<bl_fail_trigger>2</bl_fail_trigger>
+	<bl_fail_count></bl_fail_count>
+	<bl_alert>0</bl_alert>
+	<bl_cf>AVG</bl_cf>
+	<repeat_alert>0</repeat_alert>
+	<notify_extra></notify_extra>
+	<notify_warning_extra></notify_warning_extra>
+	<notify_templated>on</notify_templated>
+	<notify_warning>0</notify_warning>
+	<notify_alert>0</notify_alert>
+	<snmp_event_category></snmp_event_category>
+	<snmp_event_description></snmp_event_description>
+	<snmp_event_severity>3</snmp_event_severity>
+	<snmp_event_warning_severity>2</snmp_event_warning_severity>
+	<data_type>0</data_type>
+	<show_units>off</show_units>
+	<units_suffix></units_suffix>
+	<decimals>-1</decimals>
+	<cdef>0</cdef>
+	<percent_ds>mem_buffers</percent_ds>
+	<expression></expression>
+	<upper_ds>mem_buffers</upper_ds>
+	<exempt></exempt>
+	<thold_hrule_alert>0</thold_hrule_alert>
+	<thold_hrule_warning>0</thold_hrule_warning>
+	<skipscale></skipscale>
+	<restored_alert></restored_alert>
+	<reset_ack></reset_ack>
+	<persist_ack></persist_ack>
+	<email_subject></email_subject>
+	<email_subject_warn></email_subject_warn>
+	<email_subject_restoral></email_subject_restoral>
+	<email_body>An Alert has been issued that requires your attention. &lt;br&gt;&lt;br&gt;&lt;strong&gt;Device&lt;/strong&gt;: &lt;DESCRIPTION&gt; (&lt;HOSTNAME&gt;)&lt;br&gt;&lt;strong&gt;URL&lt;/strong&gt;: &lt;URL&gt;&lt;br&gt;&lt;strong&gt;Message&lt;/strong&gt;: &lt;SUBJECT&gt;&lt;br&gt;&lt;br&gt;&lt;GRAPH&gt;</email_body>
+	<email_body_warn>A Warning has been issued that requires your attention. &lt;br&gt;&lt;br&gt;&lt;strong&gt;Device&lt;/strong&gt;: &lt;DESCRIPTION&gt; (&lt;HOSTNAME&gt;)&lt;br&gt;&lt;strong&gt;URL&lt;/strong&gt;: &lt;URL&gt;&lt;br&gt;&lt;strong&gt;Message&lt;/strong&gt;: &lt;SUBJECT&gt;&lt;br&gt;&lt;br&gt;&lt;GRAPH&gt;</email_body_warn>
+	<email_body_restoral>A Threshold has returned to normal status. &lt;br&gt;&lt;br&gt;&lt;strong&gt;Device&lt;/strong&gt;: &lt;DESCRIPTION&gt; (&lt;HOSTNAME&gt;)&lt;br&gt;&lt;strong&gt;URL&lt;/strong&gt;: &lt;URL&gt;&lt;br&gt;&lt;strong&gt;Message&lt;/strong&gt;: &lt;SUBJECT&gt;&lt;br&gt;&lt;br&gt;&lt;GRAPH&gt;</email_body_restoral>
+	<trigger_cmd_high></trigger_cmd_high>
+	<trigger_cmd_low></trigger_cmd_low>
+	<trigger_cmd_norm></trigger_cmd_norm>
+	<syslog_priority>4</syslog_priority>
+	<syslog_facility>24</syslog_facility>
+	<syslog_enabled></syslog_enabled>
+	<notes></notes>
+	<external_id></external_id>
+	<format_file>default.format</format_file>
+	<graph_timespan>7</graph_timespan>
+</template1>
+</templates>

--- a/notify_lists.php
+++ b/notify_lists.php
@@ -1169,7 +1169,7 @@ function hosts($header_label) {
 		$sql_params[] = get_request_var('id');
 	}
 
-	$sql_limit = 'LIMIT ' . ($rows*(get_request_var('page')-1)) . ',' . $rows;
+	$sql_limit = 'LIMIT ' . ($rows*(intval(get_request_var('page'))-1)) . ',' . $rows;
 	$sql_order = get_order_string();
 
 	$total_rows = db_fetch_cell_prepared("SELECT
@@ -1345,7 +1345,7 @@ function tholds($header_label) {
 	$sql_where = '';
 
 	$sort  = get_request_var('sort_column') . ' ' . get_request_var('sort_direction');
-	$limit = ($rows*(get_request_var('page')-1)) . ", $rows";
+	$limit = ($rows*(intval(get_request_var('page'))-1)) . ", $rows";
 
 	if (!isempty_request_var('template') && get_request_var('template') != '-1') {
 		$sql_where .= ($sql_where == '' ? '' : ' AND ') . 'td.data_template_id = ' . get_request_var('template');
@@ -1690,7 +1690,7 @@ function templates($header_label) {
 
 	$sql_where = '';
 	$sql_order = get_order_string();
-	$sql_limit = ' LIMIT ' . ($rows*(get_request_var('page')-1)) . ',' . $rows;
+	$sql_limit = ' LIMIT ' . ($rows*(intval(get_request_var('page'))-1)) . ',' . $rows;
 
 	if (get_request_var('associated') == 'true') {
 		$sql_where .= (!strlen($sql_where) ? 'WHERE ' : ' AND ') . '(notify_warning=' . get_request_var('id') . ' OR notify_alert=' . get_request_var('id') . ')';
@@ -2113,7 +2113,7 @@ function lists() {
 		$sql_where");
 
 	$sql_order = get_order_string();
-	$sql_limit = ' LIMIT ' . ($rows*(get_request_var('page')-1)) . ',' . $rows;
+	$sql_limit = ' LIMIT ' . ($rows*(intval(get_request_var('page'))-1)) . ',' . $rows;
 
 	$lists = db_fetch_assoc("SELECT id, name, enabled, description, emails,
 		(SELECT COUNT(id) FROM thold_data WHERE notify_alert = nl.id) as thold_alerts,

--- a/notify_queue.php
+++ b/notify_queue.php
@@ -381,7 +381,7 @@ function notify_queue() {
 		$sql_where");
 
 	$sql_order = get_order_string();
-	$sql_limit = ' LIMIT ' . ($rows*(get_request_var('page')-1)) . ',' . $rows;
+	$sql_limit = ' LIMIT ' . ($rows*(intval(get_request_var('page'))-1)) . ',' . $rows;
 
 	$notifications = db_fetch_assoc("SELECT nq.*, h.hostname
 		FROM notification_queue AS nq

--- a/thold.php
+++ b/thold.php
@@ -616,7 +616,7 @@ function list_tholds() {
 	}
 
 	$sql_order = get_order_string();
-	$sql_limit = ($rows*(get_request_var('page')-1)) . ',' . $rows;
+	$sql_limit = ($rows*(intval(get_request_var('page'))-1)) . ',' . $rows;
 	$sql_order = str_replace('ORDER BY ', '', $sql_order);
 
 	$tholds = get_allowed_thresholds($sql_where, $sql_order, $sql_limit, $total_rows);

--- a/thold_graph.php
+++ b/thold_graph.php
@@ -385,7 +385,7 @@ function tholds() {
 	html_end_box();
 
 	$sql_order   = get_order_string();
-	$sql_limit   = ($rows*(get_request_var('page')-1)) . ',' . $rows;
+	$sql_limit   = ($rows*(intval(get_request_var('page'))-1)) . ',' . $rows;
 	$sql_order   = str_replace('ORDER BY ', '', $sql_order);
 	$sql_where   = '(h.status = 3';
 	$statefilter = thold_get_state_filter(get_request_var('state'));
@@ -950,7 +950,7 @@ function hosts() {
 	$sql_where .= ($sql_where != '' ? ')':'');
 
 	$sql_order = get_order_string();
-	$sql_limit = ($rows*(get_request_var('page')-1)) . ',' . $rows;
+	$sql_limit = ($rows*(intval(get_request_var('page'))-1)) . ',' . $rows;
 	$sql_order = str_replace('ORDER BY ', '', $sql_order);
 
 	$hosts = thold_get_allowed_devices($sql_where, $sql_order, $sql_limit, $total_rows);
@@ -1457,7 +1457,7 @@ function thold_show_log() {
 	}
 
 	$sql_order = get_order_string();
-	$sql_limit = ($rows*(get_request_var('page')-1)) . ',' . $rows;
+	$sql_limit = ($rows*(intval(get_request_var('page'))-1)) . ',' . $rows;
 	$sql_order = str_replace('ORDER BY ', '', $sql_order);
 
 	$logs = get_allowed_threshold_logs($sql_where, $sql_order, $sql_limit, $total_rows);

--- a/thold_templates.php
+++ b/thold_templates.php
@@ -2195,7 +2195,7 @@ function templates() {
 	}
 
 	$sql_order = get_order_string();
-	$sql_limit = ' LIMIT ' . ($rows*(get_request_var('page')-1)) . ',' . $rows;
+	$sql_limit = ' LIMIT ' . ($rows*(intval(get_request_var('page'))-1)) . ',' . $rows;
 
 	$total_rows = db_fetch_cell('SELECT count(*)
 		FROM thold_template');


### PR DESCRIPTION
PHP 8.0+ enforces stricter type checking for arithmetic operations. When `get_request_var('page')` returns empty or non-numeric strings, multiplication with integers throws `TypeError: Unsupported operand types: string * int`, causing the plugin to disable.

## Changes

Cast page parameter to integer before arithmetic operations in pagination:

```php
// Before
$sql_limit = ($rows*(get_request_var('page')-1)) . ',' . $rows;

// After  
$sql_limit = ($rows*(intval(get_request_var('page'))-1)) . ',' . $rows;
```

**Files modified (10 instances):**
- `thold_graph.php` - 3 locations
- `thold.php` - 1 location
- `notify_lists.php` - 4 locations
- `notify_queue.php` - 1 location
- `thold_templates.php` - 1 location

## Compatibility

Backward compatible with PHP 7.x. Handles edge cases: empty strings, non-numeric values, null → default to 0.

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> 
> ----
> 
> *This section details on the original issue you should resolve*
> 
> <issue_title>PHP Error with THOLD Cacti Plugin</issue_title>
> <issue_description>I've installed the new Cacti 1.2.30 version on a Debian 6.1.135-1 server. The php version installed is 8.2.28. The THOLD plugin installed is the 1.8.2. These packages were downloaded from the latest Github available versions.
> 
> I'm observing the threshold plugin gets disabled sporadically. According to the logs, the errors are the following:
> 
> 2025-06-25 07:18:22 - CMDPHP ERROR: debounce key was truncated from debounce_page_error_thold_graph.php?headercontent=true to debounce_page_error_thold_graph.php?headercontent= Backtrace: (/help.php[43]:debounce_run_notification(), /lib/functions.php[7442]:cacti_debug_backtrace())
> 2025-06-25 07:18:22 - CMDPHP ERRORS DETECTED - DISABLING PLUGIN 'thold'
> 2025-06-25 07:18:22 - ERROR PHP ERROR in Plugin 'thold': Uncaught TypeError: Unsupported operand types: string * int in /var/www/html/cacti/plugins/thold/thold_graph.php:388 Stack trace: Cacti/plugin_thold#0 /var/www/html/cacti/plugins/thold/thold_graph.php(56): tholds() Cacti/plugin_thold#1 {main} thrown in file: /var/www/html/cacti/plugins/thold/thold_graph.php on line: 388
> 
> Any idea what can cause the errors or why the cacti application disables the plugin?
> 
> Thank you,</issue_description>
> 
> ## Comments on the Issue (you are @copilot in this section)
> 
> <comments>
> </comments>
> 


</details>


> **Custom agent used: PHP Developer**
> This custom agent acts as a PHP developer, assisting with PHP code development, debugging, and optimization.



<!-- START COPILOT CODING AGENT SUFFIX -->

- Fixes Cacti/plugin_thold#723

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/bmfmancini/plugin_thold/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
