### PR TITLE
fix(hardening): migrate RLIKE to db_qstr for SQL injection prevention

### DIFF
--- a/notify_lists.php
+++ b/notify_lists.php
@@ -1399,7 +1399,7 @@ function tholds($header_label) {
 	}
 
 	if (strlen(get_request_var('rfilter'))) {
-		$sql_where .= (!strlen($sql_where) ? '' : ' AND ') . "td.name_cache RLIKE '" . get_request_var('rfilter') . "'";
+		$sql_where .= (!strlen($sql_where) ? '' : ' AND ') . "td.name_cache RLIKE " . db_qstr(get_request_var('rfilter')) . "";
 	}
 
 	if ($statefilter != '') {
@@ -1739,7 +1739,7 @@ function templates($header_label) {
 	}
 
 	if (strlen(get_request_var('rfilter'))) {
-		$sql_where .= (!strlen($sql_where) ? 'WHERE ' : ' AND ') . "thold_template.name RLIKE '" . get_request_var('rfilter') . "'";
+		$sql_where .= (!strlen($sql_where) ? 'WHERE ' : ' AND ') . "thold_template.name RLIKE " . db_qstr(get_request_var('rfilter')) . "";
 	}
 
 	$sql = "SELECT *
@@ -2144,9 +2144,9 @@ function lists() {
 	// form the 'where' clause for our main sql query
 	if (strlen(get_request_var('rfilter'))) {
 		$sql_where = "WHERE (
-		name RLIKE '" . get_request_var('rfilter') . "'
-		OR description RLIKE '" . get_request_var('rfilter') . "'
-		OR emails RLIKE '" . get_request_var('rfilter') . "')";
+		name RLIKE " . db_qstr(get_request_var('rfilter')) . "
+		OR description RLIKE " . db_qstr(get_request_var('rfilter')) . "
+		OR emails RLIKE " . db_qstr(get_request_var('rfilter')) . ")";
 	} else {
 		$sql_where = '';
 	}

--- a/thold.php
+++ b/thold.php
@@ -614,7 +614,7 @@ function list_tholds() {
 	}
 
 	if (get_request_var('rfilter') != '') {
-		$sql_where .= ($sql_where == '' ? '(' : ' AND ') . " td.name_cache RLIKE '" . get_request_var('rfilter') . "'";
+		$sql_where .= ($sql_where == '' ? '(' : ' AND ') . " td.name_cache RLIKE " . db_qstr(get_request_var('rfilter')) . "";
 	}
 
 	if ($statefilter != '') {

--- a/thold_graph.php
+++ b/thold_graph.php
@@ -404,7 +404,7 @@ function tholds() {
 	$statefilter = thold_get_state_filter(get_request_var('state'));
 
 	if (get_request_var('rfilter') != '') {
-		$sql_where .= ($sql_where == '' ? '(' : ' AND ') . " td.name_cache RLIKE '" . get_request_var('rfilter') . "'";
+		$sql_where .= ($sql_where == '' ? '(' : ' AND ') . " td.name_cache RLIKE " . db_qstr(get_request_var('rfilter')) . "";
 	}
 
 	if (get_request_var('data_template_id') != '-1') {
@@ -937,8 +937,8 @@ function hosts() {
 
 	if (get_request_var('rfilter') != '') {
 		$sql_where .= " (h.deleted = ''
-			AND (h.hostname RLIKE '" . get_request_var('rfilter') . "'
-			OR h.description RLIKE '" . get_request_var('rfilter') . "')";
+			AND (h.hostname RLIKE " . db_qstr(get_request_var('rfilter')) . "
+			OR h.description RLIKE " . db_qstr(get_request_var('rfilter')) . ")";
 	}
 
 	if (get_request_var('host_status') == '-1') {
@@ -1395,7 +1395,7 @@ function thold_export_log() {
 	}
 
 	if (get_request_var('rfilter') != '') {
-		$sql_where .= ($sql_where == '' ? '' : ' AND') . " tl.description RLIKE '" . get_request_var('rfilter') . "'";
+		$sql_where .= ($sql_where == '' ? '' : ' AND') . " tl.description RLIKE " . db_qstr(get_request_var('rfilter')) . "";
 	}
 
 	$sql_order  = '';
@@ -1490,7 +1490,7 @@ function thold_show_log() {
 	}
 
 	if (get_request_var('rfilter') != '') {
-		$sql_where .= ($sql_where == '' ? '' : ' AND') . " tl.description RLIKE '" . get_request_var('rfilter') . "'";
+		$sql_where .= ($sql_where == '' ? '' : ' AND') . " tl.description RLIKE " . db_qstr(get_request_var('rfilter')) . "";
 	}
 
 	$sql_order = get_order_string();


### PR DESCRIPTION
## Summary

Wrap all get_request_var('rfilter') values with db_qstr() in RLIKE SQL clauses. 10 sites across 3 files.

rfilter passes FILTER_VALIDATE_IS_REGEX (valid PCRE) but is not SQL-safe. A single quote in the regex breaks the SQL string context, enabling injection.

## Files changed

- thold.php (1 site)
- thold_graph.php (5 sites)
- notify_lists.php (4 sites)

## Test plan

- [ ] Filter thresholds by name with special characters
- [ ] Filter threshold logs
- [ ] Filter notify list templates and thresholds

Closes #761, #763