### PR TITLE
fix: normalize nullable notification text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * issue#710: Fixing Typo in thold_daemons.service File
 * issue#714: Increase the Name column to 255 characters
 * issue#719: Plugin Disabled due to mix of string and int
+* issue#814: Normalize nullable notification template text before replacement
 * issue: All Columns checkd on Thresholds page
 * issue: Special character previous value handling broken on data query indexes with special characters
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ and become familiar with its settings.  From there, you can provide overall
 control of thold, and set defaults for things like Email bodies, weekend
 exemptions, alert log retention, logging, etc.
 
+Optional notification template fields that are unset are treated as empty
+text, so an empty description or replacement does not abort delivery.
+
 As with much of Cacti, settings should be documented in line with the actual
 setting.  If you find that any of these settings are ambiguous, please create a
 pull request with your proposed changes.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ and become familiar with its settings.  From there, you can provide overall
 control of thold, and set defaults for things like Email bodies, weekend
 exemptions, alert log retention, logging, etc.
 
-Optional notification template fields that are unset are treated as empty
-text, so an empty description or replacement does not abort delivery.
+An unset notification template field is treated as empty text.
 
 As with much of Cacti, settings should be documented in line with the actual
 setting.  If you find that any of these settings are ambiguous, please create a

--- a/tests/Unit/TholdStrReplaceTest.php
+++ b/tests/Unit/TholdStrReplaceTest.php
@@ -96,7 +96,24 @@ final class TholdStrReplaceTest extends TestCase {
 	 * @return void
 	 */
 	public function testNullableSubjectIsNormalizedAtTheBoundary(): void {
-		$this->assertSame('', thold_str_replace('<X>', 'value', null));
-		$this->assertSame('', thold_str_replace('<X>', null, null));
+		$deprecations = [];
+		set_error_handler(static function ($severity, $message) use (&$deprecations) {
+			if ($severity === E_DEPRECATED) {
+				$deprecations[] = $message;
+
+				return true;
+			}
+
+			return false;
+		});
+
+		try {
+			$this->assertSame('', thold_str_replace('<X>', 'value', null));
+			$this->assertSame('', thold_str_replace('<X>', null, null));
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame([], $deprecations);
 	}
 }

--- a/tests/Unit/TholdStrReplaceTest.php
+++ b/tests/Unit/TholdStrReplaceTest.php
@@ -91,4 +91,13 @@ final class TholdStrReplaceTest extends TestCase {
 	public function testSubjectWithoutTheTagIsUnchanged(): void {
 		$this->assertSame('no tags here', thold_str_replace('<X>', 5, 'no tags here'));
 	}
+
+	/**
+	 * @return void
+	 */
+	public function testNullableInputsAreNormalizedAtTheBoundary(): void {
+		$this->assertSame('', thold_str_replace('<X>', 'value', null));
+		$this->assertSame('subject', thold_str_replace(null, 'value', 'subject'));
+		$this->assertSame('', thold_str_replace(null, null, null));
+	}
 }

--- a/tests/Unit/TholdStrReplaceTest.php
+++ b/tests/Unit/TholdStrReplaceTest.php
@@ -95,9 +95,8 @@ final class TholdStrReplaceTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testNullableInputsAreNormalizedAtTheBoundary(): void {
+	public function testNullableSubjectIsNormalizedAtTheBoundary(): void {
 		$this->assertSame('', thold_str_replace('<X>', 'value', null));
-		$this->assertSame('subject', thold_str_replace(null, 'value', 'subject'));
-		$this->assertSame('', thold_str_replace(null, null, null));
+		$this->assertSame('', thold_str_replace('<X>', null, null));
 	}
 }

--- a/thold_functions.php
+++ b/thold_functions.php
@@ -8371,12 +8371,12 @@ function thold_rlike_clause($value) {
  * blanking it produced alert bodies reading "Current value is " for exactly
  * the case an operator most needs to see.
  *
- * @param string $search  Tag to replace.
- * @param mixed  $replace Value to substitute.
- * @param string $subject Text containing the tag.
+ * @param string      $search  Tag to replace.
+ * @param mixed       $replace Value to substitute.
+ * @param string|null $subject Text containing the tag.
  */
-function thold_str_replace($search, $replace, $subject): string {
-	return str_replace((string) ($search ?? ''), (string) ($replace ?? ''), (string) ($subject ?? ''));
+function thold_str_replace(string $search, $replace, ?string $subject): string {
+	return str_replace($search, $replace ?? '', $subject ?? '');
 }
 
 function thold_template_import($xml_data) {

--- a/thold_functions.php
+++ b/thold_functions.php
@@ -8375,8 +8375,8 @@ function thold_rlike_clause($value) {
  * @param mixed  $replace Value to substitute.
  * @param string $subject Text containing the tag.
  */
-function thold_str_replace(string $search, $replace, string $subject): string {
-	return str_replace($search, $replace ?? '', $subject);
+function thold_str_replace($search, $replace, $subject): string {
+	return str_replace((string) ($search ?? ''), (string) ($replace ?? ''), (string) ($subject ?? ''));
 }
 
 function thold_template_import($xml_data) {


### PR DESCRIPTION
Notification text columns can be NULL, and PHP 8 makes passing NULL into the string functions a deprecation rather than an empty string.

Normalises the values at read time.

Closes #814.
